### PR TITLE
Simplify site design and refine accessible navigation

### DIFF
--- a/assets/css/_prose.css
+++ b/assets/css/_prose.css
@@ -1,11 +1,18 @@
 .prose-article {
+  overflow-wrap: anywhere;
+
   /* Headings */
   @apply prose-headings:font-semibold prose-headings:tracking-tight;
 
   /* Links */
-  @apply prose-a:text-primary prose-a:no-underline;
+  @apply prose-a:text-primary prose-a:underline;
+  & :where(a) {
+    text-decoration-color: color-mix(in oklab, var(--color-primary) 55%, transparent);
+    text-underline-offset: 0.15em;
+  }
+
   & :where(a:hover) {
-    @apply underline;
+    text-decoration-color: var(--color-primary);
   }
 
   /* Inline code */
@@ -13,9 +20,13 @@
 
   /* Code blocks */
   @apply prose-pre:border-base-content/5 prose-pre:border;
+  & :where(pre) {
+    overflow-x: auto;
+    overflow-wrap: normal;
+  }
 
   /* Images */
-  @apply prose-img:rounded-xl prose-img:shadow-lg;
+  @apply prose-img:rounded-lg;
 
   /* Reset inline code styles inside pre blocks */
   & pre code {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -16,10 +16,10 @@
   --color-base-300: oklch(90.5% 0.005 255);
   --color-base-content: oklch(27% 0.008 255);
 
-  /* Restrained blue primary, with clay and slate supporting accents. */
+  /* Restrained blue primary with cool slate supporting accents. */
   --color-primary: oklch(45% 0.14 255);
   --color-primary-content: oklch(98% 0.002 255);
-  --color-secondary: oklch(49% 0.1 45);
+  --color-secondary: oklch(49% 0.04 255);
   --color-secondary-content: oklch(98% 0.002 255);
   --color-accent: oklch(43% 0.08 245);
   --color-accent-content: oklch(98% 0.002 255);
@@ -42,29 +42,29 @@
   color-scheme: dark;
 
   /* Charcoal surfaces keep long reading sessions comfortable. */
-  --color-base-100: oklch(22% 0.004 70);
-  --color-base-200: oklch(26% 0.004 70);
-  --color-base-300: oklch(31% 0.004 70);
-  --color-base-content: oklch(92% 0.006 85);
+  --color-base-100: oklch(22% 0.004 255);
+  --color-base-200: oklch(26% 0.004 255);
+  --color-base-300: oklch(31% 0.004 255);
+  --color-base-content: oklch(92% 0.006 255);
 
   /* The same accents are lifted for dark-surface contrast. */
   --color-primary: oklch(72% 0.11 255);
-  --color-primary-content: oklch(22% 0.004 70);
-  --color-secondary: oklch(75% 0.1 55);
-  --color-secondary-content: oklch(22% 0.004 70);
+  --color-primary-content: oklch(22% 0.004 255);
+  --color-secondary: oklch(75% 0.04 255);
+  --color-secondary-content: oklch(22% 0.004 255);
   --color-accent: oklch(75% 0.08 245);
-  --color-accent-content: oklch(22% 0.004 70);
+  --color-accent-content: oklch(22% 0.004 255);
 
-  --color-neutral: oklch(37% 0.03 70);
-  --color-neutral-content: oklch(92% 0.006 85);
+  --color-neutral: oklch(37% 0.008 255);
+  --color-neutral-content: oklch(92% 0.006 255);
   --color-info: oklch(74% 0.1 245);
-  --color-info-content: oklch(22% 0.004 70);
+  --color-info-content: oklch(22% 0.004 255);
   --color-success: oklch(73% 0.1 160);
-  --color-success-content: oklch(22% 0.004 70);
+  --color-success-content: oklch(22% 0.004 255);
   --color-warning: oklch(80% 0.15 80);
-  --color-warning-content: oklch(22% 0.004 70);
+  --color-warning-content: oklch(22% 0.004 255);
   --color-error: oklch(72% 0.15 25);
-  --color-error-content: oklch(22% 0.004 70);
+  --color-error-content: oklch(22% 0.004 255);
 }
 
 @plugin "../vendor/heroicons";

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -42,29 +42,29 @@
   color-scheme: dark;
 
   /* Charcoal surfaces keep long reading sessions comfortable. */
-  --color-base-100: oklch(22% 0.02 70);
-  --color-base-200: oklch(26% 0.022 70);
-  --color-base-300: oklch(31% 0.025 70);
-  --color-base-content: oklch(92% 0.018 85);
+  --color-base-100: oklch(22% 0.004 70);
+  --color-base-200: oklch(26% 0.004 70);
+  --color-base-300: oklch(31% 0.004 70);
+  --color-base-content: oklch(92% 0.006 85);
 
   /* The same accents are lifted for dark-surface contrast. */
   --color-primary: oklch(72% 0.11 165);
-  --color-primary-content: oklch(22% 0.02 70);
+  --color-primary-content: oklch(22% 0.004 70);
   --color-secondary: oklch(75% 0.1 55);
-  --color-secondary-content: oklch(22% 0.02 70);
+  --color-secondary-content: oklch(22% 0.004 70);
   --color-accent: oklch(75% 0.08 245);
-  --color-accent-content: oklch(22% 0.02 70);
+  --color-accent-content: oklch(22% 0.004 70);
 
   --color-neutral: oklch(37% 0.03 70);
-  --color-neutral-content: oklch(92% 0.018 85);
+  --color-neutral-content: oklch(92% 0.006 85);
   --color-info: oklch(74% 0.1 245);
-  --color-info-content: oklch(22% 0.02 70);
+  --color-info-content: oklch(22% 0.004 70);
   --color-success: oklch(73% 0.1 160);
-  --color-success-content: oklch(22% 0.02 70);
+  --color-success-content: oklch(22% 0.004 70);
   --color-warning: oklch(80% 0.15 80);
-  --color-warning-content: oklch(22% 0.02 70);
+  --color-warning-content: oklch(22% 0.004 70);
   --color-error: oklch(72% 0.15 25);
-  --color-error-content: oklch(22% 0.02 70);
+  --color-error-content: oklch(22% 0.004 70);
 }
 
 @plugin "../vendor/heroicons";

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -105,6 +105,11 @@ html :focus-visible {
   outline-offset: 3px;
 }
 
+/* Composite inputs draw their focus ring around the icon and field together. */
+html .input input:focus-visible {
+  outline: none;
+}
+
 /* Keep daisyUI controls, menus, and dialogs calm; loading indicators keep their own motion. */
 .btn,
 .btn:active,

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,31 +2,69 @@
 @plugin "@tailwindcss/typography";
 
 @plugin "daisyui" {
-  themes:
-    light,
-    dark --default --prefersdark,
-    night,
-    sunset,
-    dracula;
+  themes: light --default, dark --prefersdark;
 }
 
 @plugin "daisyui/theme" {
   name: "light";
-  --color-secondary: oklch(68.011% 0.158 276.934);
-  --color-primary: oklch(0.488 0.243 264.376);
-  --color-primary-content: oklch(97% 0.014 264.376);
+  default: true;
+  color-scheme: light;
+
+  /* Warm paper surfaces and quiet, high-contrast ink. */
+  --color-base-100: oklch(98% 0.015 90);
+  --color-base-200: oklch(95.5% 0.02 90);
+  --color-base-300: oklch(90.5% 0.03 88);
+  --color-base-content: oklch(27% 0.025 70);
+
+  /* Muted evergreen, clay, and slate accents. */
+  --color-primary: oklch(45% 0.1 165);
+  --color-primary-content: oklch(98% 0.01 90);
+  --color-secondary: oklch(49% 0.1 45);
+  --color-secondary-content: oklch(98% 0.01 90);
+  --color-accent: oklch(43% 0.08 245);
+  --color-accent-content: oklch(98% 0.01 90);
+
+  --color-neutral: oklch(31% 0.03 70);
+  --color-neutral-content: oklch(98% 0.01 90);
+  --color-info: oklch(55% 0.12 245);
+  --color-info-content: oklch(98% 0.01 90);
+  --color-success: oklch(50% 0.1 160);
+  --color-success-content: oklch(98% 0.01 90);
+  --color-warning: oklch(74% 0.15 80);
+  --color-warning-content: oklch(27% 0.025 70);
+  --color-error: oklch(56% 0.16 25);
+  --color-error-content: oklch(98% 0.01 90);
 }
 
 @plugin "daisyui/theme" {
   name: "dark";
-  --color-primary: oklch(68.5% 0.169 237.323);
-  --color-primary-content: oklch(15% 0.034 237.323);
-  --color-secondary: oklch(68.011% 0.158 276.934);
-}
+  prefersdark: true;
+  color-scheme: dark;
 
-@plugin "daisyui/theme" {
-  name: "night";
-  --color-base-content: oklch(97.807% 0.029 256.847);
+  /* Charcoal surfaces keep long reading sessions comfortable. */
+  --color-base-100: oklch(22% 0.02 70);
+  --color-base-200: oklch(26% 0.022 70);
+  --color-base-300: oklch(31% 0.025 70);
+  --color-base-content: oklch(92% 0.018 85);
+
+  /* The same accents are lifted for dark-surface contrast. */
+  --color-primary: oklch(72% 0.11 165);
+  --color-primary-content: oklch(22% 0.02 70);
+  --color-secondary: oklch(75% 0.1 55);
+  --color-secondary-content: oklch(22% 0.02 70);
+  --color-accent: oklch(75% 0.08 245);
+  --color-accent-content: oklch(22% 0.02 70);
+
+  --color-neutral: oklch(37% 0.03 70);
+  --color-neutral-content: oklch(92% 0.018 85);
+  --color-info: oklch(74% 0.1 245);
+  --color-info-content: oklch(22% 0.02 70);
+  --color-success: oklch(73% 0.1 160);
+  --color-success-content: oklch(22% 0.02 70);
+  --color-warning: oklch(80% 0.15 80);
+  --color-warning-content: oklch(22% 0.02 70);
+  --color-error: oklch(72% 0.15 25);
+  --color-error-content: oklch(22% 0.02 70);
 }
 
 @plugin "../vendor/heroicons";
@@ -46,19 +84,55 @@
     "Monaco", "Liberation Mono", "DejaVu Sans Mono", "Courier New", "monospace";
 }
 
-/* Smooth font rendering */
+/* Keep the type crisp against both neutral surfaces. */
 html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Respect reduced motion preferences */
+/* Use the active semantic theme for native controls and browser UI. */
+html[data-theme="light"] {
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+/* Make keyboard focus visible without changing pointer focus styling. */
+html :focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
+/* Keep daisyUI controls, menus, and dialogs calm; loading indicators keep their own motion. */
+.btn,
+.btn:active,
+.dropdown-content,
+.menu,
+.menu :where(li > *:not(ul, menu, details, .menu-title, .btn)),
+.menu :where(li > details > summary),
+.menu :where(li > details > summary)::after,
+.menu :where(li > .menu-dropdown-toggle)::after,
+.menu details::details-content,
+.modal,
+.modal-box,
+.modal-backdrop,
+.modal::backdrop {
+  animation: none;
+  transition: none;
+}
+
+.btn:active,
+.dropdown-content,
+.modal-box {
+  translate: none;
+  scale: 1;
+}
+
+/* Respect reduced motion for the active-reader status indicator only. */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+  .animate-ping {
+    animation: none !important;
   }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -10,30 +10,30 @@
   default: true;
   color-scheme: light;
 
-  /* Warm paper surfaces and quiet, high-contrast ink. */
-  --color-base-100: oklch(98% 0.015 90);
-  --color-base-200: oklch(95.5% 0.02 90);
-  --color-base-300: oklch(90.5% 0.03 88);
-  --color-base-content: oklch(27% 0.025 70);
+  /* Cool gray surfaces and quiet, high-contrast ink. */
+  --color-base-100: oklch(98% 0.002 255);
+  --color-base-200: oklch(95.5% 0.003 255);
+  --color-base-300: oklch(90.5% 0.005 255);
+  --color-base-content: oklch(27% 0.008 255);
 
-  /* Muted evergreen, clay, and slate accents. */
-  --color-primary: oklch(45% 0.1 165);
-  --color-primary-content: oklch(98% 0.01 90);
+  /* Restrained blue primary, with clay and slate supporting accents. */
+  --color-primary: oklch(45% 0.14 255);
+  --color-primary-content: oklch(98% 0.002 255);
   --color-secondary: oklch(49% 0.1 45);
-  --color-secondary-content: oklch(98% 0.01 90);
+  --color-secondary-content: oklch(98% 0.002 255);
   --color-accent: oklch(43% 0.08 245);
-  --color-accent-content: oklch(98% 0.01 90);
+  --color-accent-content: oklch(98% 0.002 255);
 
-  --color-neutral: oklch(31% 0.03 70);
-  --color-neutral-content: oklch(98% 0.01 90);
+  --color-neutral: oklch(31% 0.008 255);
+  --color-neutral-content: oklch(98% 0.002 255);
   --color-info: oklch(55% 0.12 245);
-  --color-info-content: oklch(98% 0.01 90);
+  --color-info-content: oklch(98% 0.002 255);
   --color-success: oklch(50% 0.1 160);
-  --color-success-content: oklch(98% 0.01 90);
+  --color-success-content: oklch(98% 0.002 255);
   --color-warning: oklch(74% 0.15 80);
-  --color-warning-content: oklch(27% 0.025 70);
+  --color-warning-content: oklch(27% 0.008 255);
   --color-error: oklch(56% 0.16 25);
-  --color-error-content: oklch(98% 0.01 90);
+  --color-error-content: oklch(98% 0.002 255);
 }
 
 @plugin "daisyui/theme" {
@@ -48,7 +48,7 @@
   --color-base-content: oklch(92% 0.006 85);
 
   /* The same accents are lifted for dark-surface contrast. */
-  --color-primary: oklch(72% 0.11 165);
+  --color-primary: oklch(72% 0.11 255);
   --color-primary-content: oklch(22% 0.004 70);
   --color-secondary: oklch(75% 0.1 55);
   --color-secondary-content: oklch(22% 0.004 70);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -34,13 +34,12 @@ const liveSocket = new LiveSocket('/live', Socket, {
 
 // Show a theme-aware progress bar on live navigation and form submits.
 topbar.config({
-  barColors: { 0: '#4d8c7d' },
   shadowBlur: 0,
   shadowColor: 'transparent'
 })
 
 const themePrimary = () =>
-  window.getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() || '#4d8c7d'
+  window.getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() || window.getComputedStyle(document.documentElement).color
 
 window.addEventListener('phx:page-loading-start', _info => {
   topbar.config({ barColors: { 0: themePrimary() } })

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,3 @@
-/* global localStorage */
 // If you want to use Phoenix channels, run `mix help phx.gen.channel`
 // to get started and then uncomment the line below.
 // import "./user_socket.js"
@@ -27,18 +26,26 @@ import { hooks as colocatedHooks } from 'phoenix-colocated/website'
 import topbar from 'topbar'
 import * as Hooks from './hooks'
 
-// Set the theme on page load
-document.documentElement.setAttribute('data-theme', localStorage.getItem('theme') || 'dark')
-
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute('content')
 const liveSocket = new LiveSocket('/live', Socket, {
   params: { _csrf_token: csrfToken },
   hooks: { ...Hooks, ...colocatedHooks }
 })
 
-// Show progress bar on live navigation and form submits
-topbar.config({ barColors: { 0: '#29d' }, shadowColor: 'rgba(0, 0, 0, .3)' })
-window.addEventListener('phx:page-loading-start', _info => topbar.show(500))
+// Show a theme-aware progress bar on live navigation and form submits.
+topbar.config({
+  barColors: { 0: '#4d8c7d' },
+  shadowBlur: 0,
+  shadowColor: 'transparent'
+})
+
+const themePrimary = () =>
+  window.getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() || '#4d8c7d'
+
+window.addEventListener('phx:page-loading-start', _info => {
+  topbar.config({ barColors: { 0: themePrimary() } })
+  topbar.show(500)
+})
 window.addEventListener('phx:page-loading-stop', _info => topbar.hide())
 
 // connect if there are any LiveViews on the page

--- a/assets/js/hooks/searchModal.js
+++ b/assets/js/hooks/searchModal.js
@@ -59,6 +59,8 @@ const SearchModal = {
         return
       }
 
+      if (e.target.id !== 'search-input') return
+
       if (e.key === 'ArrowDown' && count > 0) {
         e.preventDefault()
         this.selectedIndex = Math.min(this.selectedIndex + 1, count - 1)

--- a/assets/js/hooks/themeSwitch.js
+++ b/assets/js/hooks/themeSwitch.js
@@ -1,10 +1,32 @@
-/* global localStorage */
+const THEMES = new Set(['light', 'dark'])
+
 export default {
   mounted () {
-    this.el.addEventListener('change-theme', (event) => {
-      const theme = event.detail.theme
+    this.handleThemeChange = (event) => {
+      const requestedTheme = event.detail?.theme
+      const theme = THEMES.has(requestedTheme) ? requestedTheme : 'dark'
+
       document.documentElement.setAttribute('data-theme', theme)
-      localStorage.setItem('theme', theme)
+      this.syncThemeButtons(theme)
+
+      try {
+        window.localStorage.setItem('theme', theme)
+      } catch (_error) {
+        // Theme switching still works when storage is unavailable.
+      }
+    }
+
+    this.el.addEventListener('change-theme', this.handleThemeChange)
+    this.syncThemeButtons(document.documentElement.dataset.theme)
+  },
+
+  destroyed () {
+    this.el.removeEventListener('change-theme', this.handleThemeChange)
+  },
+
+  syncThemeButtons (theme) {
+    this.el.querySelectorAll('[data-theme-value]').forEach((button) => {
+      button.setAttribute('aria-pressed', String(button.dataset.themeValue === theme))
     })
   }
 }

--- a/assets/js/hooks/themeSwitch.js
+++ b/assets/js/hooks/themeSwitch.js
@@ -7,6 +7,7 @@ export default {
       const theme = THEMES.has(requestedTheme) ? requestedTheme : 'dark'
 
       document.documentElement.setAttribute('data-theme', theme)
+      document.documentElement.dataset.themePreference = theme
       this.syncThemeButtons(theme)
 
       try {
@@ -16,11 +17,18 @@ export default {
       }
     }
 
+    this.handleSystemThemeChange = () => this.syncThemeButtons(document.documentElement.dataset.theme)
+    window.addEventListener('theme-changed', this.handleSystemThemeChange)
     this.el.addEventListener('change-theme', this.handleThemeChange)
     this.syncThemeButtons(document.documentElement.dataset.theme)
   },
 
+  updated () {
+    this.syncThemeButtons(document.documentElement.dataset.theme)
+  },
+
   destroyed () {
+    window.removeEventListener('theme-changed', this.handleSystemThemeChange)
     this.el.removeEventListener('change-theme', this.handleThemeChange)
   },
 

--- a/assets/js/hooks/tocHighlight.js
+++ b/assets/js/hooks/tocHighlight.js
@@ -1,8 +1,8 @@
 /* global IntersectionObserver, CSS */
 export default {
   mounted () {
-    const anchors = document.querySelectorAll('article .anchor[id]')
-    if (anchors.length === 0) return
+    const headings = document.querySelectorAll('.prose-article :is(h1, h2, h3, h4, h5, h6)[id]')
+    if (headings.length === 0) return
 
     this.tocLinks = this.el.querySelectorAll('a[href^="#"]')
 
@@ -10,19 +10,18 @@ export default {
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
-            const anchor = entry.target.querySelector('.anchor[id]')
-            if (anchor) this.activate(anchor.id)
+            this.activate(entry.target.id)
           }
         }
       },
       { rootMargin: '0px 0px -70% 0px', threshold: 0 }
     )
 
-    for (const anchor of anchors) {
-      this.observer.observe(anchor.parentElement)
+    for (const heading of headings) {
+      this.observer.observe(heading)
     }
 
-    this.activateFirstVisible(anchors)
+    this.activateFirstVisible(headings)
   },
 
   destroyed () {
@@ -42,20 +41,20 @@ export default {
     }
   },
 
-  activateFirstVisible (anchors) {
-    for (const anchor of anchors) {
-      const rect = anchor.parentElement.getBoundingClientRect()
+  activateFirstVisible (headings) {
+    for (const heading of headings) {
+      const rect = heading.getBoundingClientRect()
       if (rect.top >= 0 && rect.top < window.innerHeight * 0.3) {
-        this.activate(anchor.id)
+        this.activate(heading.id)
         return
       }
     }
 
     // If no heading is in the top 30%, activate the last one above the viewport
     let lastAbove = null
-    for (const anchor of anchors) {
-      if (anchor.parentElement.getBoundingClientRect().top < 0) {
-        lastAbove = anchor
+    for (const heading of headings) {
+      if (heading.getBoundingClientRect().top < 0) {
+        lastAbove = heading
       }
     }
     if (lastAbove) this.activate(lastAbove.id)

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,38 @@
+(() => {
+  const supportedThemes = new Set(['light', 'dark'])
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
+  let storedTheme = null
+
+  try {
+    storedTheme = window.localStorage.getItem('theme')
+  } catch (_error) {
+    // Use the system preference when browser storage is unavailable.
+  }
+
+  const theme = storedTheme === null
+    ? (prefersDark.matches ? 'dark' : 'light')
+    : (supportedThemes.has(storedTheme) ? storedTheme : 'dark')
+
+  document.documentElement.setAttribute('data-theme', theme)
+  document.documentElement.dataset.themePreference = storedTheme === null ? 'system' : theme
+
+  if (storedTheme !== null && !supportedThemes.has(storedTheme)) {
+    try {
+      window.localStorage.setItem('theme', 'dark')
+    } catch (_error) {
+      // The selected theme is already applied for this page.
+    }
+  }
+
+  if (storedTheme === null) {
+    prefersDark.addEventListener('change', (event) => {
+      if (document.documentElement.dataset.themePreference !== 'system') return
+
+      document.documentElement.setAttribute(
+        'data-theme',
+        event.matches ? 'dark' : 'light'
+      )
+      window.dispatchEvent(new window.Event('theme-changed'))
+    })
+  }
+})()

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :esbuild,
   version: "0.28.1",
   default: [
     args:
-      ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
+      ~w(js/app.js js/theme.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
   ]

--- a/lib/website/blog/article_impl.ex
+++ b/lib/website/blog/article_impl.ex
@@ -4,7 +4,7 @@ defimpl SEO.OpenGraph.Build, for: Website.Blog.Article do
   def build(article, _conn) do
     og_img =
       SEO.OpenGraph.Image.build(%{
-        url: "https://og-image.farens.me/image?text=#{URI.encode(article.title)}",
+        url: "https://og-image.farens.me/image?v=2&text=#{URI.encode(article.title)}",
         alt: article.title
       })
 
@@ -39,7 +39,7 @@ defimpl SEO.Twitter.Build, for: Website.Blog.Article do
     SEO.Twitter.build(
       description: article.description,
       title: article.title,
-      image: "https://og-image.farens.me/image?text=#{URI.encode(article.title)}"
+      image: "https://og-image.farens.me/image?v=2&text=#{URI.encode(article.title)}"
     )
   end
 end
@@ -71,7 +71,7 @@ defimpl SEO.JSONLD.Build, for: Website.Blog.Article do
             name: "Florian Arens",
             url: url(conn, ~p"/about")
           }),
-        image: "https://og-image.farens.me/image?text=#{URI.encode(article.title)}",
+        image: "https://og-image.farens.me/image?v=2&text=#{URI.encode(article.title)}",
         keywords: article.tags,
         main_entity_of_page: article_url
       }),

--- a/lib/website/markdown_converter.ex
+++ b/lib/website/markdown_converter.ex
@@ -9,7 +9,7 @@ defmodule Website.MarkdownConverter do
       parse: [smart: true],
       syntax_highlight: [
         engine: :lumis,
-        opts: [formatter: {:html_inline, theme: "tokyonight_storm"}]
+        opts: [formatter: {:html_inline, theme: "github_dark"}]
       ]
     )
   end

--- a/lib/website_web/components/core_components.ex
+++ b/lib/website_web/components/core_components.ex
@@ -434,13 +434,13 @@ defmodule WebsiteWeb.CoreComponents do
       aria-label="Table of contents"
       class={["group", "**:data-toc-active:text-primary **:data-toc-active:border-primary/50", @class]}
     >
-      <.section_label :if={@show_label} class="mb-4">On this page</.section_label>
-      <ul class="space-y-1">
+      <.section_label :if={@show_label} class="mb-2">On this page</.section_label>
+      <ul class="space-y-0.5">
         <li :for={%{label: label, href: href, childs: childs} <- @headings}>
           <.link
             href={href}
             class={[
-              "text-base-content/70 min-h-11 flex items-center py-1.5 text-sm",
+              "text-base-content/70 min-h-11 flex items-center py-1 text-sm xl:min-h-9",
               "hover:text-primary",
               "border-l-2 border-transparent pl-3",
               "hover:border-primary/50"
@@ -448,11 +448,11 @@ defmodule WebsiteWeb.CoreComponents do
           >
             {label}
           </.link>
-          <ul :if={childs != []} class="ml-3 space-y-1">
+          <ul :if={childs != []} class="ml-3 space-y-0.5">
             <li :for={%{label: child_label, href: child_href} <- childs}>
               <.link
                 href={child_href}
-                class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary"
+                class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary xl:min-h-9"
               >
                 {child_label}
               </.link>
@@ -461,11 +461,11 @@ defmodule WebsiteWeb.CoreComponents do
         </li>
       </ul>
     </nav>
-    <ul :if={!@is_root} class="ml-3 space-y-1">
+    <ul :if={!@is_root} class="ml-3 space-y-0.5">
       <li :for={%{label: label, href: href, childs: childs} <- @headings}>
         <.link
           href={href}
-          class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary"
+          class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary xl:min-h-9"
         >
           {label}
         </.link>

--- a/lib/website_web/components/core_components.ex
+++ b/lib/website_web/components/core_components.ex
@@ -12,10 +12,7 @@ defmodule WebsiteWeb.CoreComponents do
 
   @themes [
     %{label: "Light", theme: "light", icon: "hero-sun"},
-    %{label: "Dark", theme: "dark", icon: "hero-moon"},
-    %{label: "Night", theme: "night", icon: "hero-star"},
-    %{label: "Sunset", theme: "sunset", icon: "hero-sun"},
-    %{label: "Dracula", theme: "dracula", icon: "hero-paint-brush"}
+    %{label: "Dark", theme: "dark", icon: "hero-moon"}
   ]
 
   @doc """
@@ -25,7 +22,7 @@ defmodule WebsiteWeb.CoreComponents do
 
   def title(assigns) do
     ~H"""
-    <h1 class="text-base-content text-3xl font-bold md:text-4xl">
+    <h1 class="text-base-content text-2xl font-semibold tracking-tight sm:text-3xl">
       {@text}
     </h1>
     """
@@ -46,7 +43,7 @@ defmodule WebsiteWeb.CoreComponents do
     <.title :if={@title} text={@title} />
     <div
       :if={@inner_block != []}
-      class="text-base-content/70 text-pretty mt-6 mb-10 leading-relaxed lg:w-2/3"
+      class="text-base-content/70 text-pretty mt-6 mb-10 leading-relaxed"
     >
       {render_slot(@inner_block)}
     </div>
@@ -61,7 +58,7 @@ defmodule WebsiteWeb.CoreComponents do
 
   def section_label(assigns) do
     ~H"""
-    <p class={["text-base-content/70 text-xs font-semibold uppercase tracking-wider", @class]}>
+    <p class={["text-base-content/70 text-sm font-medium", @class]}>
       {render_slot(@inner_block)}
     </p>
     """
@@ -77,16 +74,19 @@ defmodule WebsiteWeb.CoreComponents do
 
   def modal(assigns) do
     ~H"""
-    <dialog id={@id} class="modal">
+    <dialog id={@id} class="modal" aria-labelledby={@header && "#{@id}-title"}>
       <div class="modal-box">
         <form method="dialog">
-          <button class="btn btn-sm btn-circle btn-ghost absolute top-2 right-2" aria-label="Close">
+          <button
+            class="btn btn-circle btn-ghost min-h-11 min-w-11 absolute top-2 right-2"
+            aria-label="Close"
+          >
             ✕
           </button>
         </form>
-        <h3 :if={@header} class="text-base-content text-lg font-bold">
+        <h2 :if={@header} id={"#{@id}-title"} class="text-base-content text-lg font-bold">
           {@header}
-        </h3>
+        </h2>
         {render_slot(@inner_block)}
       </div>
       <form method="dialog" class="modal-backdrop">
@@ -106,44 +106,27 @@ defmodule WebsiteWeb.CoreComponents do
 
   def navbar(assigns) do
     ~H"""
-    <nav aria-label="Main navigation" class="flex h-20">
-      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4">
-        <.avatar />
-
-        <div class={[
-          "hidden items-center gap-1 sm:flex",
-          "bg-base-200/80 rounded-box",
-          "border-base-content/5 border",
-          "px-1.5 py-1"
-        ]}>
+    <nav aria-label="Main navigation" class="mx-auto w-full max-w-3xl px-6 pt-6 sm:pt-10">
+      <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <.link navigate={~p"/"} class="min-h-11 inline-flex items-center font-semibold tracking-tight">
+          Florian Arens
+        </.link>
+        <div class="flex items-center gap-1">
+          <.search_button :if={@show_search} />
+          <.theme_switch />
+        </div>
+        <div class="flex w-full flex-wrap items-center gap-x-6">
           <.link
             :for={%{label: label, to: to} <- main_navigation_links()}
             navigate={to}
             aria-current={active?(@current_url, to) && "page"}
             class={[
-              "rounded-box px-4 py-2 text-sm font-medium",
-              "transition-colors duration-200",
-              if(active?(@current_url, to),
-                do: "text-primary bg-primary/10",
-                else: "text-base-content hover:bg-base-content/5"
-              )
+              "min-h-11 inline-flex items-center text-sm underline-offset-4 hover:underline",
+              if(active?(@current_url, to), do: "font-medium underline", else: "text-base-content/70")
             ]}
           >
             {label}
           </.link>
-        </div>
-
-        <button
-          class="btn flex items-center font-semibold sm:hidden"
-          onclick="document.getElementById('mobile_navigation').showModal()"
-        >
-          <span>Menu</span>
-          <.icon name="hero-bars-3" class="size-4" />
-        </button>
-
-        <div class="flex items-center gap-2">
-          <.search_button :if={@show_search} />
-          <.theme_switch />
         </div>
       </div>
     </nav>
@@ -155,22 +138,16 @@ defmodule WebsiteWeb.CoreComponents do
     ~H"""
     <.link
       navigate={~p"/"}
-      class={[
-        "group relative",
-        "rounded-full",
-        "ring-2 ring-transparent",
-        "transition-[box-shadow] duration-300",
-        "hover:ring-primary/20 hover:ring-offset-base-100 hover:ring-offset-2"
-      ]}
+      class="min-h-11 min-w-11 inline-flex items-center"
+      aria-label="Florian Arens — Home"
     >
-      <div class="size-10 overflow-hidden rounded-full">
-        <img
-          loading="lazy"
-          src={~p"/images/me.jpg"}
-          alt="Portrait of Florian"
-          class="transition-[scale] h-full w-full object-cover duration-300 group-hover:scale-110"
-        />
-      </div>
+      <img
+        src={~p"/images/me.jpg"}
+        alt="Portrait of Florian"
+        width="40"
+        height="40"
+        class="size-10 rounded-full object-cover"
+      />
     </.link>
     """
   end
@@ -183,18 +160,10 @@ defmodule WebsiteWeb.CoreComponents do
     <button
       onclick="window.dispatchEvent(new CustomEvent('open-search'))"
       aria-label="Search articles"
-      class={[
-        "btn font-normal",
-        "hover:bg-base-content/5",
-        "transition-colors duration-200",
-        "border-base-content/5 border"
-      ]}
+      class="min-h-11 text-base-content/70 inline-flex items-center gap-2 px-3 text-sm underline-offset-4 hover:underline"
     >
       <.icon name="hero-magnifying-glass" class="size-4" />
-      <span class="hidden md:inline">Search...</span>
-      <kbd class="bg-base-300/80 font-mono border-base-content/10 hidden rounded border px-1.5 py-0.5 text-xs md:inline">
-        ⌘K
-      </kbd>
+      <span>Search</span>
     </button>
     """
   end
@@ -206,53 +175,29 @@ defmodule WebsiteWeb.CoreComponents do
     assigns = assign(assigns, :themes, @themes)
 
     ~H"""
-    <div
-      id="theme_switch"
-      phx-hook="ThemeSwitch"
-      title="Change theme"
-      class="dropdown dropdown-end"
-    >
-      <div
-        tabindex="0"
-        role="button"
-        class={[
-          "btn",
-          "hover:bg-base-content/5",
-          "transition-colors duration-200",
-          "border-base-content/5 border"
-        ]}
+    <details id="theme_switch" phx-hook="ThemeSwitch" class="dropdown dropdown-end">
+      <summary
+        class="min-h-11 min-w-11 inline-flex cursor-pointer list-none items-center justify-center"
+        aria-label="Switch theme"
       >
-        <.icon name="hero-swatch" class="size-4" />
-        <.icon name="hero-chevron-down" class="size-3 opacity-40" />
-        <span class="sr-only">Switch theme</span>
-      </div>
-      <ul
-        tabindex="0"
-        class={[
-          "dropdown-content menu",
-          "mt-3 w-56 p-2",
-          "bg-base-100/95 backdrop-blur-md",
-          "rounded-2xl",
-          "border-base-content/5 border",
-          "shadow-base-content/10 shadow-xl",
-          "z-50"
-        ]}
-      >
+        <.icon name="hero-sun" class="size-4" />
+      </summary>
+      <ul class="dropdown-content menu border-base-content/15 bg-base-100 z-50 w-36 rounded-md border p-1">
         <li :for={%{label: label, theme: theme, icon: icon} <- @themes}>
           <button
-            class={[
-              "flex items-center gap-3 rounded-xl px-3 py-2.5",
-              "transition-colors duration-150",
-              "hover:bg-base-content/5"
-            ]}
-            phx-click={JS.dispatch("change-theme", detail: %{theme: theme})}
+            class="min-h-11 gap-2 rounded-sm"
+            data-theme-value={theme}
+            phx-click={
+              JS.dispatch("change-theme", detail: %{theme: theme})
+              |> JS.remove_attribute("open", to: "#theme_switch")
+            }
           >
-            <.icon name={icon} class="size-4 opacity-60" />
-            <span class="flex-1 text-left">{label}</span>
+            <.icon name={icon} class="size-4" />
+            {label}
           </button>
         </li>
       </ul>
-    </div>
+    </details>
     """
   end
 
@@ -265,19 +210,19 @@ defmodule WebsiteWeb.CoreComponents do
   def share_article_dropdown(assigns) do
     ~H"""
     <div id="share_container" phx-hook="WebShareApi" data-title={@title} data-url={@link}>
-      <button data-share-web-share class="btn btn-ghost btn-sm btn-square hidden">
+      <button data-share-web-share class="btn btn-ghost btn-square min-h-11 min-w-11 hidden">
         <.icon name="hero-share" />
         <span class="sr-only">Share</span>
       </button>
       <details id="share_dropdown" data-share-fallback class="dropdown dropdown-end hidden">
         <summary
-          class="btn btn-ghost btn-sm btn-square"
+          class="btn btn-ghost btn-square min-h-11 min-w-11"
           phx-click-away={JS.remove_attribute("open", to: "#share_dropdown")}
         >
           <.icon name="hero-share" />
           <span class="sr-only">Share</span>
         </summary>
-        <ul class="menu dropdown-content bg-base-100/95 border-base-content/5 shadow-base-content/10 z-50 w-40 rounded-2xl border p-2 shadow-xl backdrop-blur-md">
+        <ul class="menu dropdown-content bg-base-100 border-base-content/15 z-50 w-40 rounded-md border p-2">
           <li>
             <.link
               href={"https://x.com/intent/tweet?text=#{@title}&url=#{@link}&via=flo_arens"}
@@ -299,70 +244,6 @@ defmodule WebsiteWeb.CoreComponents do
   end
 
   @doc """
-  Renders the mobile navigation modal.
-  """
-  attr :current_url, :string, required: true
-
-  def mobile_navigation(assigns) do
-    ~H"""
-    <dialog id="mobile_navigation" class="modal modal-bottom">
-      <div class={[
-        "modal-box rounded-t-3xl",
-        "bg-base-100/95 backdrop-blur-md",
-        "border-base-content/5 border-t",
-        "pb-safe"
-      ]}>
-        <div class="flex justify-center pb-4">
-          <div class="bg-base-content/20 h-1.5 w-12 rounded-full" />
-        </div>
-
-        <form method="dialog" class="absolute top-4 right-4">
-          <button class="btn btn-sm btn-circle btn-ghost" aria-label="Close navigation">
-            <.icon name="hero-x-mark" class="size-5" />
-          </button>
-        </form>
-
-        <nav aria-label="Mobile navigation" class="flex flex-col gap-1 px-2 pb-4">
-          <.link
-            :for={%{label: label, to: to} <- main_navigation_links()}
-            navigate={to}
-            onclick="document.getElementById('mobile_navigation').close()"
-            aria-current={active?(@current_url, to) && "page"}
-            class={[
-              "flex items-center gap-4 rounded-2xl px-4 py-4",
-              "text-lg font-medium",
-              "transition-colors duration-200",
-              "active:scale-[0.98]",
-              "hover:bg-base-content/5"
-            ]}
-          >
-            <span class="flex-1">{label}</span>
-            <.icon name="hero-chevron-right" class="size-5 text-base-content/70" />
-          </.link>
-        </nav>
-
-        <div class="border-base-content/5 border-t px-6 pt-4">
-          <.section_label class="mb-3">Connect</.section_label>
-          <.contact_links
-            class="flex gap-2"
-            icon_class={[
-              "size-11 p-2.5",
-              "rounded-xl",
-              "text-base-content/70 fill-current",
-              "hover:text-primary hover:bg-base-content/5",
-              "transition-colors"
-            ]}
-          />
-        </div>
-      </div>
-      <form method="dialog" class="modal-backdrop bg-base-content/50 backdrop-blur-sm">
-        <button aria-label="Close navigation">{gettext("close")}</button>
-      </form>
-    </dialog>
-    """
-  end
-
-  @doc """
   Renders a footer.
   """
   attr :class, :string, default: nil
@@ -370,63 +251,18 @@ defmodule WebsiteWeb.CoreComponents do
 
   def footer(assigns) do
     ~H"""
-    <footer class="border-base-content/5 relative mt-8 border-t md:mt-12">
-      <div class="from-base-100 bg-linear-to-t pointer-events-none absolute inset-x-0 -top-8 h-8 to-transparent md:-top-12 md:h-12" />
-
-      <div class="mx-auto w-full max-w-6xl px-4 py-12 md:py-16">
-        <div class="grid grid-cols-1 gap-8 md:grid-cols-3 md:gap-12">
-          <div class="md:col-span-1">
-            <.link navigate={~p"/"} class="group inline-flex items-center gap-3">
-              <div class="ring-base-content/5 transition-[box-shadow] h-10 w-10 overflow-hidden rounded-full ring-2 duration-200 group-hover:ring-primary/20">
-                <img src={~p"/images/me.jpg"} alt="Florian" class="h-full w-full object-cover" />
-              </div>
-              <span class="text-base-content font-semibold">Florian Arens</span>
-            </.link>
-            <p class="text-base-content/70 mt-4 max-w-xs text-sm">
-              Software Engineer passionate about leveraging AI to accelerate software development.
-            </p>
-          </div>
-
-          <nav aria-label="Footer navigation" class="md:col-span-1">
-            <.section_label class="mb-4">Navigation</.section_label>
-            <div class="flex flex-col gap-2">
-              <.link
-                :for={%{label: label, to: to} <- main_navigation_links()}
-                navigate={to}
-                aria-current={active?(@current_url, to) && "page"}
-                class={[
-                  "text-base-content/70 text-sm transition-colors duration-150 hover:text-primary",
-                  active?(@current_url, to) && "text-primary"
-                ]}
-              >
-                {label}
-              </.link>
-            </div>
-          </nav>
-
-          <div class="md:col-span-1">
-            <.section_label class="mb-4">Connect</.section_label>
-            <.contact_links
-              class="flex gap-3"
-              icon_class="size-5 p-3 box-content text-base-content/70 hover:text-primary transition-colors duration-150 fill-current"
-            />
-          </div>
-        </div>
-
-        <div class="border-base-content/5 mt-12 flex flex-col gap-4 border-t pt-6 md:flex-row md:items-center md:justify-between">
-          <p class="text-base-content/70 text-xs">
-            &copy; {Date.utc_today().year} Florian Arens. All rights reserved.
-          </p>
-          <nav class="flex gap-4" aria-label="Legal">
-            <.link
-              :for={%{label: label, to: to} <- secondary_navigation_links()}
-              navigate={to}
-              class="text-base-content/70 text-xs transition-colors duration-150 hover:text-base-content"
-            >
-              {label}
-            </.link>
-          </nav>
-        </div>
+    <footer class={["mx-auto mt-16 w-full max-w-3xl px-6 pb-8", @class]}>
+      <div class="border-base-content/15 text-base-content/70 flex flex-col gap-2 border-t pt-5 text-sm sm:flex-row sm:items-center sm:justify-between">
+        <p>&copy; {Date.utc_today().year} Florian Arens</p>
+        <nav class="flex flex-wrap gap-x-5" aria-label="Legal">
+          <.link
+            :for={%{label: label, to: to} <- secondary_navigation_links()}
+            navigate={to}
+            class="min-h-11 inline-flex items-center underline-offset-4 hover:underline"
+          >
+            {label}
+          </.link>
+        </nav>
       </div>
     </footer>
     """
@@ -436,30 +272,25 @@ defmodule WebsiteWeb.CoreComponents do
   Renders all contact links.
   """
   attr :class, :string, default: nil
-  attr :icon_class, :any, required: true
+  attr :icon_class, :any, default: nil
 
   def contact_links(assigns) do
     ~H"""
-    <div class={@class}>
-      <.link href="https://github.com/flo0807" target="_blank" rel="noopener noreferrer">
-        <span class="sr-only">GitHub</span>
-        <.github_icon class={@icon_class} />
-      </.link>
-      <.link href="https://linkedin.com/in/florian-arens" target="_blank" rel="noopener noreferrer">
-        <span class="sr-only">LinkedIn</span>
-        <.linkedin_icon class={@icon_class} />
-      </.link>
-      <.link href="https://bsky.app/profile/farens.me" target="_blank" rel="noopener noreferrer">
-        <span class="sr-only">Bluesky</span>
-        <.bluesky_icon class={@icon_class} />
-      </.link>
-      <.link href="https://x.com/flo_arens" target="_blank" rel="noopener noreferrer">
-        <span class="sr-only">X</span>
-        <.x_icon class={@icon_class} />
-      </.link>
-      <.link href="mailto:info@farens.me">
-        <span class="sr-only">Mail</span>
-        <.mail_icon class={@icon_class} />
+    <div class={["flex flex-wrap gap-x-5", @class]}>
+      <.link
+        :for={
+          {label, href} <- [
+            {"GitHub", "https://github.com/flo0807"},
+            {"LinkedIn", "https://linkedin.com/in/florian-arens"},
+            {"Bluesky", "https://bsky.app/profile/farens.me"},
+            {"X", "https://x.com/flo_arens"},
+            {"Email", "mailto:info@farens.me"}
+          ]
+        }
+        href={href}
+        class="min-h-11 decoration-base-content/30 inline-flex items-center text-sm underline underline-offset-4 hover:decoration-current"
+      >
+        {label}
       </.link>
     </div>
     """
@@ -473,51 +304,25 @@ defmodule WebsiteWeb.CoreComponents do
   attr :link_label, :string, required: true
   attr :link, :string, required: true
 
+  attr :heading_level, :atom, default: :h2
+
   def project_card(assigns) do
     ~H"""
-    <.link href={@link} target="_blank" rel="noopener noreferrer">
-      <article class={[
-        "group relative h-full",
-        "rounded-2xl",
-        "from-base-200 to-base-200/50 bg-linear-to-b",
-        "border-base-content/5 border",
-        "p-6",
-        "transition-[translate,box-shadow,border-color] duration-300 ease-out",
-        "hover:border-base-content/10",
-        "hover:shadow-base-content/5 hover:shadow-lg",
-        "hover:-translate-y-1"
-      ]}>
-        <div class="from-primary/5 to-secondary/5 bg-linear-to-br absolute inset-0 rounded-2xl via-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-
-        <div class="relative">
-          <div class="flex items-start justify-between">
-            <h2 class="text-base-content text-lg font-semibold transition-colors duration-200 group-hover:text-primary">
-              {@title}
-            </h2>
-            <.icon
-              name="hero-arrow-up-right"
-              class={[
-                "size-5 text-base-content/70",
-                "transition-[color,translate] duration-200",
-                "group-hover:text-primary",
-                "group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-              ]}
-            />
-          </div>
-
-          <p class="text-base-content/70 mt-3 text-sm leading-relaxed">
-            {@description}
-          </p>
-
-          <div class="text-base-content/70 mt-4 flex items-center gap-2 text-sm">
-            <.icon name="hero-link" class="size-4" />
-            <span class="transition-colors duration-200 group-hover:text-primary group-hover:underline">
-              {@link_label}
-            </span>
-          </div>
-        </div>
-      </article>
-    </.link>
+    <article class="py-5">
+      <.dynamic_tag tag_name={to_string(@heading_level)} class="text-base font-medium">
+        <.link
+          href={@link}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="min-h-11 decoration-base-content/30 inline-flex items-center underline underline-offset-4 hover:decoration-current"
+        >
+          {@title}
+          <span class="sr-only"> (opens in a new tab)</span>
+        </.link>
+      </.dynamic_tag>
+      <p class="text-base-content/70 mt-1 leading-relaxed">{@description}</p>
+      <span class="text-base-content/70 mt-2 block text-sm">{@link_label}</span>
+    </article>
     """
   end
 
@@ -529,7 +334,7 @@ defmodule WebsiteWeb.CoreComponents do
 
   def grid(assigns) do
     ~H"""
-    <div class={["grid gap-5 md:grid-cols-2 lg:grid-cols-3", @class]}>
+    <div class={["divide-base-content/15 divide-y", @class]}>
       {render_slot(@inner_block)}
     </div>
     """
@@ -548,82 +353,33 @@ defmodule WebsiteWeb.CoreComponents do
   attr :read_minutes, :integer, required: true
   attr :heading_level, :atom, default: :h2
 
+  attr :compact, :boolean, default: false
+
   def blog_preview_card(assigns) do
-    assigns = assign(assigns, :heading_tag, to_string(assigns.heading_level))
-
     ~H"""
-    <.link id={@id} navigate={@link}>
-      <article class={[
-        "group relative h-full",
-        "rounded-2xl",
-        "from-base-200 to-base-200/50 bg-linear-to-br",
-        "border-base-content/5 border",
-        "p-6",
-        "transition-[translate,box-shadow,border-color] duration-300 ease-out",
-        "hover:border-base-content/10",
-        "hover:shadow-base-content/5 hover:shadow-lg",
-        "hover:-translate-y-1",
-        @class
-      ]}>
-        <div class="from-primary/5 to-secondary/5 bg-linear-to-br absolute inset-0 rounded-2xl via-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-
-        <div class="relative flex h-full flex-col">
-          <div class="text-base-content/70 flex items-center gap-3 text-xs font-medium">
-            <time datetime={@date}>
-              {Calendar.strftime(@date, "%b %d, %Y")}
-            </time>
-            <span class="bg-base-content/20 h-1 w-1 rounded-full" aria-hidden="true" />
-            <span>{@read_minutes} min read</span>
-          </div>
-
-          <.dynamic_tag
-            tag_name={@heading_tag}
-            class={[
-              "mt-4 text-lg font-semibold leading-snug",
-              "text-base-content",
-              "transition-colors duration-200",
-              "group-hover:text-primary"
-            ]}
+    <article id={@id} class={["py-5", @class]}>
+      <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6">
+        <.dynamic_tag
+          tag_name={to_string(@heading_level)}
+          class="min-w-0 text-base font-medium leading-relaxed"
+        >
+          <.link
+            navigate={@link}
+            class="min-h-11 decoration-base-content/30 inline-flex items-center underline underline-offset-4 hover:decoration-current"
           >
             {@title}
-          </.dynamic_tag>
-
-          <div :if={@tags != []} class="mt-3 flex flex-wrap gap-2">
-            <span
-              :for={tag <- @tags}
-              class={[
-                "inline-flex items-center",
-                "px-2.5 py-0.5",
-                "text-xs font-medium",
-                "rounded-full",
-                "bg-base-content/5 text-base-content/70",
-                "transition-colors duration-200",
-                "group-hover:bg-primary/10 group-hover:text-primary"
-              ]}
-            >
-              {tag}
-            </span>
-          </div>
-
-          <p class="text-base-content/70 line-clamp-3 mt-4 text-sm leading-relaxed">
-            {@description}
-          </p>
-
-          <div class={[
-            "mt-auto flex items-center gap-2 pt-6",
-            "text-base-content/70 text-sm font-medium",
-            "transition-[color,gap] duration-200",
-            "group-hover:text-primary group-hover:gap-3"
-          ]}>
-            <span>Read article</span>
-            <.icon
-              name="hero-arrow-right"
-              class="size-4 transition-[translate] duration-200 group-hover:translate-x-1"
-            />
-          </div>
-        </div>
-      </article>
-    </.link>
+          </.link>
+        </.dynamic_tag>
+        <time datetime={@date} class="text-base-content/70 shrink-0 text-sm">
+          {Calendar.strftime(@date, "%b %d, %Y")}
+        </time>
+      </div>
+      <p :if={!@compact} class="text-base-content/70 mt-2 leading-relaxed">{@description}</p>
+      <div :if={!@compact} class="text-base-content/70 mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+        <span>{@read_minutes} min read</span>
+        <span :for={tag <- @tags}>{tag}</span>
+      </div>
+    </article>
     """
   end
 
@@ -637,27 +393,19 @@ defmodule WebsiteWeb.CoreComponents do
 
   def blog_tags(assigns) do
     ~H"""
-    <section id={@id} class="space-y-4">
+    <section id={@id} aria-label="Filter by topic">
       <.section_label>Filter by topic</.section_label>
-
-      <div class="flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-x-5">
         <button
           :for={tag <- @tags}
           phx-click={@select_event}
           phx-value-tag={tag}
           aria-pressed={to_string(String.downcase(tag) == @search_tag)}
           class={[
-            "inline-flex items-center px-2.5 py-1",
-            "text-xs font-medium",
-            "rounded-full",
-            "cursor-pointer border",
-            "transition-colors duration-200",
+            "min-h-11 cursor-pointer text-sm underline-offset-4 hover:underline",
             if(String.downcase(tag) == @search_tag,
-              do: ["bg-primary/10 text-primary border-primary/20", "shadow-primary/10 shadow-sm"],
-              else: [
-                "bg-base-200/50 text-base-content/70 border-base-content/5",
-                "hover:bg-base-200 hover:text-base-content hover:border-base-content/10"
-              ]
+              do: "font-medium underline",
+              else: "text-base-content/70"
             )
           ]}
         >
@@ -674,6 +422,7 @@ defmodule WebsiteWeb.CoreComponents do
   attr :headings, :list, required: true
   attr :class, :string, default: nil
   attr :is_root, :boolean, default: true
+  attr :show_label, :boolean, default: true
 
   def toc(assigns) do
     ~H"""
@@ -684,15 +433,15 @@ defmodule WebsiteWeb.CoreComponents do
       aria-label="Table of contents"
       class={["group", "**:data-toc-active:text-primary **:data-toc-active:border-primary/50", @class]}
     >
-      <.section_label class="mb-4">On this page</.section_label>
+      <.section_label :if={@show_label} class="mb-4">On this page</.section_label>
       <ul class="space-y-1">
         <li :for={%{label: label, href: href, childs: childs} <- @headings}>
           <.link
             href={href}
             class={[
-              "text-base-content/70 block py-1.5 text-sm",
+              "text-base-content/70 min-h-11 flex items-center py-1.5 text-sm",
               "hover:text-primary",
-              "transition-colors duration-150",
+              "",
               "border-l-2 border-transparent pl-3",
               "hover:border-primary/50"
             ]}
@@ -703,7 +452,7 @@ defmodule WebsiteWeb.CoreComponents do
             <li :for={%{label: child_label, href: child_href} <- childs}>
               <.link
                 href={child_href}
-                class="text-base-content/70 block py-1 pl-3 text-xs transition-colors duration-150 hover:text-primary"
+                class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary"
               >
                 {child_label}
               </.link>
@@ -716,7 +465,7 @@ defmodule WebsiteWeb.CoreComponents do
       <li :for={%{label: label, href: href, childs: childs} <- @headings}>
         <.link
           href={href}
-          class="text-base-content/70 block py-1 pl-3 text-xs transition-colors duration-150 hover:text-primary"
+          class="text-base-content/70 min-h-11 flex items-center py-1 pl-3 text-sm hover:text-primary"
         >
           {label}
         </.link>

--- a/lib/website_web/components/core_components.ex
+++ b/lib/website_web/components/core_components.ex
@@ -185,7 +185,7 @@ defmodule WebsiteWeb.CoreComponents do
       <ul class="dropdown-content menu border-base-content/15 bg-base-100 z-50 w-36 rounded-md border p-1">
         <li :for={%{label: label, theme: theme, icon: icon} <- @themes}>
           <button
-            class="min-h-11 gap-2 rounded-sm"
+            class="min-h-11 content-center gap-2 rounded-sm"
             data-theme-value={theme}
             phx-click={
               JS.dispatch("change-theme", detail: %{theme: theme})

--- a/lib/website_web/components/core_components.ex
+++ b/lib/website_web/components/core_components.ex
@@ -252,7 +252,7 @@ defmodule WebsiteWeb.CoreComponents do
   def footer(assigns) do
     ~H"""
     <footer class={["mx-auto mt-16 w-full max-w-3xl px-6 pb-8", @class]}>
-      <div class="border-base-content/15 text-base-content/70 flex flex-col gap-2 border-t pt-5 text-sm sm:flex-row sm:items-center sm:justify-between">
+      <div class="text-base-content/70 flex flex-col gap-2 pt-5 text-sm sm:flex-row sm:items-center sm:justify-between">
         <p>&copy; {Date.utc_today().year} Florian Arens</p>
         <nav class="flex flex-wrap gap-x-5" aria-label="Legal">
           <.link
@@ -334,7 +334,7 @@ defmodule WebsiteWeb.CoreComponents do
 
   def grid(assigns) do
     ~H"""
-    <div class={["divide-base-content/15 divide-y", @class]}>
+    <div class={@class}>
       {render_slot(@inner_block)}
     </div>
     """

--- a/lib/website_web/components/core_components.ex
+++ b/lib/website_web/components/core_components.ex
@@ -419,6 +419,7 @@ defmodule WebsiteWeb.CoreComponents do
   @doc """
   Renders a table of contents from a list of headings.
   """
+  attr :id, :string, default: "toc"
   attr :headings, :list, required: true
   attr :class, :string, default: nil
   attr :is_root, :boolean, default: true
@@ -428,7 +429,7 @@ defmodule WebsiteWeb.CoreComponents do
     ~H"""
     <nav
       :if={@is_root}
-      id="toc"
+      id={@id}
       phx-hook="TocHighlight"
       aria-label="Table of contents"
       class={["group", "**:data-toc-active:text-primary **:data-toc-active:border-primary/50", @class]}
@@ -441,7 +442,6 @@ defmodule WebsiteWeb.CoreComponents do
             class={[
               "text-base-content/70 min-h-11 flex items-center py-1.5 text-sm",
               "hover:text-primary",
-              "",
               "border-l-2 border-transparent pl-3",
               "hover:border-primary/50"
             ]}

--- a/lib/website_web/components/layouts.ex
+++ b/lib/website_web/components/layouts.ex
@@ -20,16 +20,22 @@ defmodule WebsiteWeb.Layouts do
   def app(assigns) do
     ~H"""
     <div class="flex min-h-screen flex-col">
-      <.mobile_navigation current_url={@current_url} />
       <.live_component module={WebsiteWeb.SearchLive} id="global-search" />
+      <a
+        href="#main-content"
+        class="sr-only focus:bg-base-100 focus:not-sr-only focus:absolute focus:z-50 focus:p-4"
+      >Skip to content</a>
       <header>
         <.navbar current_url={@current_url} />
       </header>
-      <main class={[
-        "relative mx-auto w-full max-w-6xl px-4",
-        "pt-8 pb-4 md:pt-12 md:pb-6 lg:pt-16 lg:pb-8",
-        "flex-1"
-      ]}>
+      <main
+        id="main-content"
+        class={[
+          "relative mx-auto w-full max-w-3xl px-6",
+          "pt-8 pb-4 md:pt-12 md:pb-6 lg:pt-16 lg:pb-8",
+          "flex-1"
+        ]}
+      >
         {render_slot(@inner_block)}
       </main>
       <.footer current_url={@current_url} />

--- a/lib/website_web/components/layouts.ex
+++ b/lib/website_web/components/layouts.ex
@@ -14,6 +14,7 @@ defmodule WebsiteWeb.Layouts do
 
   """
   attr :current_url, :string, required: true
+  attr :main_class, :string, default: "pt-8 pb-4 md:pt-12 md:pb-6 lg:pt-16 lg:pb-8"
 
   slot :inner_block, required: true
 
@@ -30,11 +31,7 @@ defmodule WebsiteWeb.Layouts do
       </header>
       <main
         id="main-content"
-        class={[
-          "relative mx-auto w-full max-w-3xl px-6",
-          "pt-8 pb-4 md:pt-12 md:pb-6 lg:pt-16 lg:pb-8",
-          "flex-1"
-        ]}
+        class={["relative mx-auto w-full max-w-3xl px-6", @main_class, "flex-1"]}
       >
         {render_slot(@inner_block)}
       </main>

--- a/lib/website_web/components/layouts/error.html.heex
+++ b/lib/website_web/components/layouts/error.html.heex
@@ -1,21 +1,23 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark" class="h-full scroll-smooth">
+<html lang="en" data-theme="light" class="h-full">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="csrf-token" content={get_csrf_token()} />
+    <meta name="color-scheme" content="light dark" />
+    <script phx-track-static src={~p"/assets/js/theme.js"}>
+    </script>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static src={~p"/assets/js/app.js"}>
     </script>
     <link rel="alternate" type="application/rss+xml" href={url(~p"/rss.xml")} />
   </head>
   <body class="h-full">
-    <.mobile_navigation current_url={Map.get(@conn, :request_path, "/")} />
     <div class="flex h-full flex-col">
       <header>
         <.navbar current_url={Map.get(@conn, :request_path, "/")} show_search={false} />
       </header>
-      <main class="mx-auto my-8 w-full max-w-6xl px-4 md:my-12">
+      <main class="mx-auto my-8 w-full max-w-3xl px-6 md:my-12">
         {@inner_content}
       </main>
       <div class="mt-auto">

--- a/lib/website_web/components/layouts/root.html.heex
+++ b/lib/website_web/components/layouts/root.html.heex
@@ -5,47 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <meta name="color-scheme" content="light dark" />
-    <script>
-      (() => {
-        const supportedThemes = new Set(["light", "dark"])
-        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
-        let storedTheme = null
-
-        try {
-          storedTheme = window.localStorage.getItem("theme")
-        } catch (_error) {
-          // Use the system preference when browser storage is unavailable.
-        }
-
-        const theme = storedTheme === null
-          ? (prefersDark.matches ? "dark" : "light")
-          : (supportedThemes.has(storedTheme) ? storedTheme : "dark")
-
-        document.documentElement.setAttribute("data-theme", theme)
-
-        if (storedTheme !== null && !supportedThemes.has(storedTheme)) {
-          try {
-            window.localStorage.setItem("theme", "dark")
-          } catch (_error) {
-            // The selected theme is already applied for this page.
-          }
-        }
-
-        if (storedTheme === null) {
-          prefersDark.addEventListener("change", (event) => {
-            try {
-              if (window.localStorage.getItem("theme") !== null) return
-            } catch (_error) {
-              // Continue following the system preference.
-            }
-
-            document.documentElement.setAttribute(
-              "data-theme",
-              event.matches ? "dark" : "light"
-            )
-          })
-        }
-      })()
+    <script phx-track-static src={~p"/assets/js/theme.js"}>
     </script>
     <SEO.juice conn={@conn} config={WebsiteWeb.SEO.config()} page_title={@page_title} />
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />

--- a/lib/website_web/components/layouts/root.html.heex
+++ b/lib/website_web/components/layouts/root.html.heex
@@ -1,9 +1,52 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark" class="[scrollbar-gutter:stable] scroll-smooth">
+<html lang="en" data-theme="light" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="csrf-token" content={get_csrf_token()} />
+    <meta name="color-scheme" content="light dark" />
+    <script>
+      (() => {
+        const supportedThemes = new Set(["light", "dark"])
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)")
+        let storedTheme = null
+
+        try {
+          storedTheme = window.localStorage.getItem("theme")
+        } catch (_error) {
+          // Use the system preference when browser storage is unavailable.
+        }
+
+        const theme = storedTheme === null
+          ? (prefersDark.matches ? "dark" : "light")
+          : (supportedThemes.has(storedTheme) ? storedTheme : "dark")
+
+        document.documentElement.setAttribute("data-theme", theme)
+
+        if (storedTheme !== null && !supportedThemes.has(storedTheme)) {
+          try {
+            window.localStorage.setItem("theme", "dark")
+          } catch (_error) {
+            // The selected theme is already applied for this page.
+          }
+        }
+
+        if (storedTheme === null) {
+          prefersDark.addEventListener("change", (event) => {
+            try {
+              if (window.localStorage.getItem("theme") !== null) return
+            } catch (_error) {
+              // Continue following the system preference.
+            }
+
+            document.documentElement.setAttribute(
+              "data-theme",
+              event.matches ? "dark" : "light"
+            )
+          })
+        }
+      })()
+    </script>
     <SEO.juice conn={@conn} config={WebsiteWeb.SEO.config()} page_title={@page_title} />
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static src={~p"/assets/js/app.js"}>

--- a/lib/website_web/init_assigns.ex
+++ b/lib/website_web/init_assigns.ex
@@ -11,7 +11,7 @@ defmodule WebsiteWeb.InitAssigns do
     socket =
       socket
       |> attach_current_url_hook()
-      |> assign(:page_title, "Florian Arens - Software Engineer")
+      |> assign(:page_title, "Florian Arens - Lead Engineer")
 
     {:cont, socket}
   end

--- a/lib/website_web/live/about_live/index.ex
+++ b/lib/website_web/live/about_live/index.ex
@@ -9,7 +9,7 @@ defmodule WebsiteWeb.AboutLive.Index do
       |> assign(:og_image_text, "About")
       |> assign(
         :meta_description,
-        "Learn about Florian Arens, a software developer and team lead passionate about Elixir, Phoenix, and functional programming."
+        "Meet Florian Arens, Lead Engineer at naymspace. I build web applications with Elixir and Phoenix LiveView and help teams use AI to make everyday work easier."
       )
 
     {:ok, socket}

--- a/lib/website_web/live/about_live/index.ex
+++ b/lib/website_web/live/about_live/index.ex
@@ -6,7 +6,7 @@ defmodule WebsiteWeb.AboutLive.Index do
     socket =
       socket
       |> assign(:page_title, "About Me - Florian Arens")
-      |> assign(:og_image_text, "About")
+      |> assign(:og_image_text, "About me: software, AI, and the work behind it.")
       |> assign(
         :meta_description,
         "Meet Florian Arens, Lead Engineer at naymspace. I build web applications with Elixir and Phoenix LiveView and help teams use AI to make everyday work easier."

--- a/lib/website_web/live/about_live/index.html.heex
+++ b/lib/website_web/live/about_live/index.html.heex
@@ -9,15 +9,14 @@
     <div class="mt-8 max-w-2xl">
       <img
         loading="eager"
-        class="mb-8 size-40 rounded-lg object-cover"
+        class="size-40 mb-8 rounded-lg object-cover"
         src="/images/me.jpg"
         alt="Portrait of Florian"
       />
 
       <div class="space-y-5 leading-relaxed">
         <p class="text-base-content/70">
-          I’m a Lead Engineer at
-          <.link
+          I’m a Lead Engineer at <.link
             href="https://naymspace.de/"
             target="_blank"
             rel="noopener noreferrer"

--- a/lib/website_web/live/about_live/index.html.heex
+++ b/lib/website_web/live/about_live/index.html.heex
@@ -1,77 +1,52 @@
 <Layouts.app current_url={@current_url}>
-  <article class="relative">
-    <header>
-      <.page_intro label="About" title="I'm Florian." />
+  <article>
+    <header class="max-w-2xl">
+      <h1 class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+        About me
+      </h1>
     </header>
 
-    <div class="mt-10 flex flex-col gap-12 lg:flex-row lg:gap-16">
-      <div class="flex-1 space-y-6">
-        <p class="text-base-content/70 leading-relaxed">
-          I work as a Lead Engineer at <.link
+    <div class="mt-8 grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start lg:gap-16">
+      <div class="max-w-2xl space-y-5 leading-relaxed">
+        <p class="text-base-content/70">
+          I’m a Lead Engineer at
+          <.link
             href="https://naymspace.de/"
             target="_blank"
             rel="noopener noreferrer"
-            class="underline"
+            class="text-base-content underline underline-offset-4"
           >naymspace</.link>,
-          where I am technically responsible for multiple projects. Driven by an entrepreneurial mindset,
-          I am passionate about leveraging AI to accelerate software development workflows, always with a focus on quality.
+          where I’m technically responsible for several projects. I care about building useful
+          software and using AI to make development workflows faster without losing quality.
         </p>
 
-        <p class="text-base-content/70 leading-relaxed">
-          I have a background in Applied Computer Science (B.Sc. & M.Sc.) and acquired my skills by
-          working on a variety of projects. I successfully completed numerous projects, both as part of
-          a team and independently. I have also participated in several research projects and gained professional
-          working experience as a Software Developer and Lead Engineer.
+        <p class="text-base-content/70">
+          I studied Applied Computer Science (B.Sc. and M.Sc.) and have worked as a software
+          developer and lead engineer across team, independent, and research projects.
         </p>
 
-        <p class="text-base-content/70 leading-relaxed">
-          Outside of work, I'm passionate about software development as well.
-          I build open source projects, explore new technologies, and enjoy attending conferences and meetups.
+        <p class="text-base-content/70">
+          In my spare time I build open source projects, explore new technologies, and attend
+          conferences and meetups. Cycling and functional strength training keep me balanced.
         </p>
 
-        <p class="text-base-content/70 leading-relaxed">
-          I find my balance in sport, which I do in a variety of ways. From cycling to
-          functional strength training, I'm always looking for new challenges. This ambition
-          is also reflected in my work and studies.
-        </p>
-
-        <div class="pt-4">
+        <p class="pt-2">
           <.link
             navigate={~p"/projects"}
-            class={[
-              "inline-flex items-center gap-2",
-              "text-primary font-medium",
-              "hover:gap-3",
-              "transition-[color,gap] duration-200",
-              "motion-reduce:transition-none"
-            ]}
+            class="text-primary font-medium underline underline-offset-4"
           >
-            View my projects <.icon name="hero-arrow-right" class="size-4" />
+            View my projects
           </.link>
-        </div>
+        </p>
       </div>
 
-      <div class="mx-auto w-64 md:w-72 lg:mx-0 lg:w-80 lg:flex-shrink-0">
-        <div class={[
-          "group relative",
-          "lg:rotate-2 lg:hover:-rotate-1",
-          "transition-[rotate] duration-500"
-        ]}>
-          <div class="from-primary/20 to-secondary/20 bg-linear-to-br absolute inset-0 rounded-2xl opacity-50 blur-xl transition-opacity duration-500 group-hover:opacity-70" />
-
-          <img
-            loading="eager"
-            class={[
-              "relative",
-              "aspect-square w-full object-cover",
-              "rounded-2xl",
-              "shadow-base-content/10 shadow-2xl",
-              "ring-base-content/5 ring-1"
-            ]}
-            src="/images/me.jpg"
-            alt="Portrait of Florian"
-          />
-        </div>
+      <div class="mx-auto w-full max-w-xs lg:mx-0 lg:max-w-none">
+        <img
+          loading="eager"
+          class="aspect-square w-full rounded-lg object-cover"
+          src="/images/me.jpg"
+          alt="Portrait of Florian"
+        />
       </div>
     </div>
   </article>

--- a/lib/website_web/live/about_live/index.html.heex
+++ b/lib/website_web/live/about_live/index.html.heex
@@ -6,8 +6,15 @@
       </h1>
     </header>
 
-    <div class="mt-8 grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-start lg:gap-16">
-      <div class="max-w-2xl space-y-5 leading-relaxed">
+    <div class="mt-8 max-w-2xl">
+      <img
+        loading="eager"
+        class="mb-8 size-40 rounded-lg object-cover"
+        src="/images/me.jpg"
+        alt="Portrait of Florian"
+      />
+
+      <div class="space-y-5 leading-relaxed">
         <p class="text-base-content/70">
           I’m a Lead Engineer at
           <.link
@@ -33,20 +40,11 @@
         <p class="pt-2">
           <.link
             navigate={~p"/projects"}
-            class="text-primary font-medium underline underline-offset-4"
+            class="text-primary min-h-11 inline-flex items-center font-medium underline underline-offset-4"
           >
             View my projects
           </.link>
         </p>
-      </div>
-
-      <div class="mx-auto w-full max-w-xs lg:mx-0 lg:max-w-none">
-        <img
-          loading="eager"
-          class="aspect-square w-full rounded-lg object-cover"
-          src="/images/me.jpg"
-          alt="Portrait of Florian"
-        />
       </div>
     </div>
   </article>

--- a/lib/website_web/live/about_live/index.html.heex
+++ b/lib/website_web/live/about_live/index.html.heex
@@ -22,18 +22,30 @@
             rel="noopener noreferrer"
             class="text-base-content underline underline-offset-4"
           >naymspace</.link>,
-          where I’m technically responsible for several projects. I care about building useful
-          software and using AI to make development workflows faster without losing quality.
+          where I take technical responsibility for internal and client projects, from the first
+          idea to implementation. I work closely with clients and build software that fits their
+          day-to-day needs.
         </p>
 
         <p class="text-base-content/70">
-          I studied Applied Computer Science (B.Sc. and M.Sc.) and have worked as a software
-          developer and lead engineer across team, independent, and research projects.
+          A big part of my work is evaluating AI tools and improving how we use them in development.
+          I care about more than what a tool can do: it should make the team’s work easier and be
+          worth the time and money we put into it.
         </p>
 
         <p class="text-base-content/70">
-          In my spare time I build open source projects, explore new technologies, and attend
-          conferences and meetups. Cycling and functional strength training keep me balanced.
+          My main tools are Elixir, Phoenix LiveView, and PostgreSQL. I also contribute to <.link
+            href="https://backpex.live/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-base-content underline underline-offset-4"
+          >Backpex</.link>,
+          an open source admin panel for Phoenix LiveView used in internal and client projects.
+          I share my experience through this blog and my own open source projects.
+        </p>
+
+        <p class="text-base-content/70">
+          Away from the keyboard, you’ll find me strength training, playing badminton, or cooking.
         </p>
 
         <p class="pt-2">

--- a/lib/website_web/live/blog_live/index.html.heex
+++ b/lib/website_web/live/blog_live/index.html.heex
@@ -31,7 +31,7 @@
       />
     </section>
 
-    <div id="articles" class="divide-base-content/10 mt-8 divide-y" phx-update="stream">
+    <div id="articles" class="mt-8" phx-update="stream">
       <div id="articles-empty" class="hidden py-12 text-center only:block">
         <p class="text-base-content/70 text-lg font-medium">No articles found</p>
         <p class="text-base-content/70 mt-1 text-sm">Try selecting a different tag</p>

--- a/lib/website_web/live/blog_live/index.html.heex
+++ b/lib/website_web/live/blog_live/index.html.heex
@@ -1,17 +1,6 @@
 <Layouts.app current_url={@current_url}>
   <div>
-    <aside class="absolute top-0 right-0 bottom-16 hidden w-64 lg:block">
-      <div class="sticky top-24">
-        <.blog_tags
-          id="desktop-tag-list"
-          tags={@all_tags}
-          search_tag={@search_tag}
-          select_event="select-tag"
-        />
-      </div>
-    </aside>
-
-    <header class="lg:w-2/3">
+    <header>
       <div class="flex items-baseline justify-between gap-4">
         <h1 id="blog-heading" class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
           Writing
@@ -19,7 +8,7 @@
 
         <button
           onclick="document.getElementById('rss-modal').showModal()"
-          class="btn btn-ghost btn-sm"
+          class="btn btn-ghost btn-sm min-h-11 inline-flex items-center gap-2"
         >
           <.icon name="hero-rss" class="size-4" /> Subscribe
         </button>
@@ -30,16 +19,16 @@
       </p>
     </header>
 
-    <section class="mt-8 lg:hidden" aria-label="Filter articles">
+    <section class="mt-8" aria-label="Filter articles">
       <.blog_tags
-        id="mobile-tag-list"
+        id="tag-list"
         tags={@all_tags}
         search_tag={@search_tag}
         select_event="select-tag"
       />
     </section>
 
-    <div id="articles" class="mt-8 divide-y divide-base-content/10 lg:w-2/3" phx-update="stream">
+    <div id="articles" class="mt-8 divide-y divide-base-content/10" phx-update="stream">
       <div id="articles-empty" class="hidden py-12 text-center only:block">
         <p class="text-base-content/70 text-lg font-medium">No articles found</p>
         <p class="text-base-content/70 mt-1 text-sm">Try selecting a different tag</p>

--- a/lib/website_web/live/blog_live/index.html.heex
+++ b/lib/website_web/live/blog_live/index.html.heex
@@ -2,7 +2,10 @@
   <div>
     <header>
       <div class="flex items-baseline justify-between gap-4">
-        <h1 id="blog-heading" class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+        <h1
+          id="blog-heading"
+          class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl"
+        >
           Writing
         </h1>
 
@@ -28,7 +31,7 @@
       />
     </section>
 
-    <div id="articles" class="mt-8 divide-y divide-base-content/10" phx-update="stream">
+    <div id="articles" class="divide-base-content/10 mt-8 divide-y" phx-update="stream">
       <div id="articles-empty" class="hidden py-12 text-center only:block">
         <p class="text-base-content/70 text-lg font-medium">No articles found</p>
         <p class="text-base-content/70 mt-1 text-sm">Try selecting a different tag</p>

--- a/lib/website_web/live/blog_live/index.html.heex
+++ b/lib/website_web/live/blog_live/index.html.heex
@@ -1,5 +1,5 @@
 <Layouts.app current_url={@current_url}>
-  <div class="relative">
+  <div>
     <aside class="absolute top-0 right-0 bottom-16 hidden w-64 lg:block">
       <div class="sticky top-24">
         <.blog_tags
@@ -12,29 +12,25 @@
     </aside>
 
     <header class="lg:w-2/3">
-      <div class="flex items-center justify-between">
-        <div>
-          <.section_label class="mb-2">Blog</.section_label>
-          <h1 class="text-base-content text-3xl font-bold md:text-4xl">
-            My Thoughts
-          </h1>
-        </div>
+      <div class="flex items-baseline justify-between gap-4">
+        <h1 id="blog-heading" class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+          Writing
+        </h1>
 
         <button
           onclick="document.getElementById('rss-modal').showModal()"
-          class="btn btn-primary btn-outline btn-sm"
+          class="btn btn-ghost btn-sm"
         >
           <.icon name="hero-rss" class="size-4" /> Subscribe
         </button>
       </div>
 
-      <p class="text-base-content/70 mt-6 max-w-xl leading-relaxed">
-        I write about software engineering, functional programming, and whatever sparks my curiosity.
-        Documenting my learning journey one article at a time.
+      <p class="text-base-content/70 mt-5 max-w-xl leading-relaxed">
+        Notes on software engineering, functional programming, and the things I’m learning.
       </p>
     </header>
 
-    <section class="mt-8 lg:hidden">
+    <section class="mt-8 lg:hidden" aria-label="Filter articles">
       <.blog_tags
         id="mobile-tag-list"
         tags={@all_tags}
@@ -43,14 +39,8 @@
       />
     </section>
 
-    <div id="articles" class="mt-10 flex flex-col gap-5 lg:w-2/3" phx-update="stream">
-      <div
-        id="articles-empty"
-        class="hidden flex-col items-center justify-center py-16 text-center only:flex"
-      >
-        <div class="bg-base-200 mb-4 flex h-16 w-16 items-center justify-center rounded-full">
-          <.icon name="hero-document-magnifying-glass" class="size-8 text-base-content/70" />
-        </div>
+    <div id="articles" class="mt-8 divide-y divide-base-content/10 lg:w-2/3" phx-update="stream">
+      <div id="articles-empty" class="hidden py-12 text-center only:block">
         <p class="text-base-content/70 text-lg font-medium">No articles found</p>
         <p class="text-base-content/70 mt-1 text-sm">Try selecting a different tag</p>
       </div>

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -40,9 +40,16 @@
         </div>
       </header>
 
-      <aside class="border-base-content/10 mt-8 border-y py-6">
-        <.toc headings={@article.heading_links} />
-      </aside>
+      <details
+        :if={@article.heading_links != []}
+        id="article-contents"
+        class="border-base-content/15 mt-6 border-y py-2"
+      >
+        <summary class="min-h-11 cursor-pointer content-center text-sm font-medium">
+          On this page
+        </summary>
+        <.toc headings={@article.heading_links} show_label={false} class="pb-4" />
+      </details>
 
       <div class="prose-article prose prose-base prose-neutral mt-10 max-w-none dark:prose-invert">
         {raw(@article.body)}

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -1,55 +1,35 @@
 <Layouts.app current_url={@current_url}>
-  <div class="relative mx-auto max-w-2xl">
-    <aside class="absolute top-0 right-full bottom-0 mr-14 hidden w-44 xl:block">
-      <div class="sticky top-20">
-        <.toc headings={@article.heading_links} />
-      </div>
-    </aside>
+  <div class="mx-auto max-w-3xl">
+    <.link
+      navigate={~p"/blog"}
+      class="text-base-content/70 text-sm underline underline-offset-4"
+    >
+      ← Back to articles
+    </.link>
 
     <article>
-      <.link
-        navigate={~p"/blog"}
-        class={[
-          "inline-flex items-center gap-2",
-          "text-base-content/70 text-sm",
-          "hover:text-primary",
-          "transition-colors duration-200",
-          "group"
-        ]}
-      >
-        <.icon
-          name="hero-arrow-left"
-          class="size-4 transition-[translate] duration-200 group-hover:-translate-x-1"
-        />
-        <span>Back to articles</span>
-      </.link>
-
       <header class="mt-8">
-        <h1 class="text-base-content text-3xl font-bold leading-tight tracking-tight md:text-4xl">
+        <h1 class="text-base-content text-3xl font-semibold leading-tight tracking-tight md:text-4xl">
           {@article.title}
         </h1>
 
-        <div class="text-base-content/70 mt-6 flex flex-wrap items-center gap-4 text-sm">
-          <div class="flex items-center gap-2">
-            <.icon name="hero-calendar" class="size-4" />
-            <time datetime={@article.date}>
-              {Calendar.strftime(@article.date, "%b %d, %Y")}
-            </time>
-          </div>
+        <div class="text-base-content/70 mt-5 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+          <time datetime={@article.date}>
+            {Calendar.strftime(@article.date, "%b %d, %Y")}
+          </time>
 
-          <span class="bg-base-content/20 h-1 w-1 rounded-full" aria-hidden="true" />
+          <span aria-hidden="true">·</span>
 
           <span>{@article.read_minutes} min read</span>
 
-          <span class="bg-base-content/20 h-1 w-1 rounded-full" aria-hidden="true" />
+          <span aria-hidden="true">·</span>
 
-          <div class="flex items-center gap-2">
-            <span class="relative flex h-2 w-2" aria-hidden="true">
-              <span class="bg-success absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
-              <span class="bg-success relative inline-flex h-2 w-2 rounded-full"></span>
+          <span class="inline-flex items-center gap-2">
+            <span class="bg-success relative flex h-2 w-2 rounded-full" aria-hidden="true">
+              <span class="bg-success absolute inline-flex h-full w-full rounded-full opacity-75 motion-safe:animate-ping"></span>
             </span>
             <span>{@live_reading} reading now</span>
-          </div>
+          </span>
 
           <div class="flex-1" />
 
@@ -60,45 +40,43 @@
         </div>
       </header>
 
+      <aside class="border-base-content/10 mt-8 border-y py-6">
+        <.toc headings={@article.heading_links} />
+      </aside>
+
       <div class="prose-article prose prose-base prose-neutral mt-10 max-w-none dark:prose-invert">
         {raw(@article.body)}
       </div>
 
-      <div :if={@article.tags != []} class="mt-12">
-        <.section_label class="mb-4">Tagged with</.section_label>
-        <div class="flex flex-wrap gap-2">
+      <section :if={@article.tags != []} class="mt-12" aria-labelledby="article-tags-heading">
+        <h2 id="article-tags-heading" class="text-base-content text-sm font-semibold">
+          Tags
+        </h2>
+        <div class="mt-3 flex flex-wrap gap-x-4 gap-y-2">
           <.link
             :for={tag <- @article.tags}
             navigate={~p"/blog/tag/#{tag}"}
-            class={[
-              "inline-flex items-center px-3 py-1.5",
-              "rounded-full text-sm font-medium",
-              "bg-base-200/50 text-base-content/70",
-              "border-base-content/5 border",
-              "hover:bg-primary/10 hover:text-primary hover:border-primary/20",
-              "transition-colors duration-200"
-            ]}
+            class="text-base-content/70 text-sm underline underline-offset-4"
           >
             {tag}
           </.link>
         </div>
-      </div>
+      </section>
 
-      <section class="mt-12">
-        <div class="mb-6 flex items-end justify-between">
-          <div>
-            <.section_label class="mb-2">Continue reading</.section_label>
-            <h2 class="text-base-content text-xl font-bold">You might also like</h2>
-          </div>
+      <section class="mt-12" aria-labelledby="more-articles-heading">
+        <div class="flex items-baseline justify-between gap-4">
+          <h2 id="more-articles-heading" class="text-base-content text-xl font-semibold">
+            More from the blog
+          </h2>
           <.link
             navigate={~p"/blog"}
-            class="text-base-content/70 text-sm transition-colors duration-150 hover:text-primary"
+            class="text-primary text-sm underline underline-offset-4"
           >
-            View all articles
+            View all
           </.link>
         </div>
 
-        <div class="grid gap-4 md:grid-cols-2">
+        <.grid class="mt-6">
           <.blog_preview_card
             :for={article <- @recommended_articles}
             id={"recommended-article-#{article.id}"}
@@ -109,8 +87,9 @@
             tags={article.tags}
             read_minutes={article.read_minutes}
             heading_level={:h3}
+            compact
           />
-        </div>
+        </.grid>
       </section>
     </article>
   </div>

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -1,5 +1,13 @@
 <Layouts.app current_url={@current_url}>
-  <div class="mx-auto max-w-3xl">
+  <div class="relative mx-auto max-w-3xl">
+    <aside
+      :if={@article.heading_links != []}
+      class="absolute inset-y-0 right-full mr-10 hidden w-52 xl:block"
+    >
+      <div class="max-h-[calc(100dvh-4rem)] sticky top-8 overflow-y-auto overscroll-contain">
+        <.toc id="desktop-toc" headings={@article.heading_links} />
+      </div>
+    </aside>
     <.link
       navigate={~p"/blog"}
       class="text-base-content/70 min-h-11 inline-flex items-center text-sm underline underline-offset-4"
@@ -43,7 +51,7 @@
       <details
         :if={@article.heading_links != []}
         id="article-contents"
-        class="mt-6 py-2"
+        class="mt-6 py-2 xl:hidden"
       >
         <summary class="min-h-11 cursor-pointer content-center text-sm font-medium">
           On this page

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -78,7 +78,7 @@
         </div>
       </section>
 
-      <section class="mt-12" aria-labelledby="more-articles-heading">
+      <section class="mt-8" aria-labelledby="more-articles-heading">
         <div class="flex items-baseline justify-between gap-4">
           <h2 id="more-articles-heading" class="text-base-content text-xl font-semibold">
             More from the blog
@@ -91,7 +91,7 @@
           </.link>
         </div>
 
-        <.grid class="mt-6">
+        <.grid class="[&>article]:py-2 mt-2">
           <.blog_preview_card
             :for={article <- @recommended_articles}
             id={"recommended-article-#{article.id}"}

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-3xl">
     <.link
       navigate={~p"/blog"}
-      class="text-base-content/70 text-sm underline underline-offset-4"
+      class="text-base-content/70 min-h-11 inline-flex items-center text-sm underline underline-offset-4"
     >
       ← Back to articles
     </.link>
@@ -56,7 +56,7 @@
           <.link
             :for={tag <- @article.tags}
             navigate={~p"/blog/tag/#{tag}"}
-            class="text-base-content/70 text-sm underline underline-offset-4"
+            class="text-base-content/70 min-h-11 inline-flex items-center text-sm underline underline-offset-4"
           >
             {tag}
           </.link>
@@ -70,9 +70,9 @@
           </h2>
           <.link
             navigate={~p"/blog"}
-            class="text-primary text-sm underline underline-offset-4"
+            class="text-primary min-h-11 inline-flex items-center text-sm underline underline-offset-4"
           >
-            View all
+            View all articles
           </.link>
         </div>
 

--- a/lib/website_web/live/blog_live/show.html.heex
+++ b/lib/website_web/live/blog_live/show.html.heex
@@ -43,7 +43,7 @@
       <details
         :if={@article.heading_links != []}
         id="article-contents"
-        class="border-base-content/15 mt-6 border-y py-2"
+        class="mt-6 py-2"
       >
         <summary class="min-h-11 cursor-pointer content-center text-sm font-medium">
           On this page

--- a/lib/website_web/live/home_live/index.ex
+++ b/lib/website_web/live/home_live/index.ex
@@ -14,7 +14,7 @@ defmodule WebsiteWeb.HomeLive.Index do
       |> assign(:articles, articles)
       |> assign(:projects, projects)
       |> assign(:page_title, "Florian Arens - Lead Engineer")
-      |> assign(:og_image_text, "Florian Arens")
+      |> assign(:og_image_text, "Building software. Putting AI to practical use.")
       |> assign(
         :meta_description,
         "Florian Arens, Lead Engineer at naymspace. I build software, put AI to practical use, and share what I learn through blog posts and my own open source projects."

--- a/lib/website_web/live/home_live/index.ex
+++ b/lib/website_web/live/home_live/index.ex
@@ -2,14 +2,17 @@ defmodule WebsiteWeb.HomeLive.Index do
   use WebsiteWeb, :live_view
 
   alias Website.Blog
+  alias Website.Projects
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     articles = Blog.all_articles() |> Enum.take(3)
+    projects = Projects.all_projects() |> Enum.take(2)
 
     socket =
       socket
       |> assign(:articles, articles)
+      |> assign(:projects, projects)
       |> assign(:page_title, "Florian Arens - Software Engineer")
       |> assign(:og_image_text, "Florian Arens")
       |> assign(

--- a/lib/website_web/live/home_live/index.ex
+++ b/lib/website_web/live/home_live/index.ex
@@ -13,11 +13,11 @@ defmodule WebsiteWeb.HomeLive.Index do
       socket
       |> assign(:articles, articles)
       |> assign(:projects, projects)
-      |> assign(:page_title, "Florian Arens - Software Engineer")
+      |> assign(:page_title, "Florian Arens - Lead Engineer")
       |> assign(:og_image_text, "Florian Arens")
       |> assign(
         :meta_description,
-        "Software Engineer passionate about leveraging AI to accelerate software development. Explore my blog, projects, and more."
+        "Florian Arens, Lead Engineer at naymspace. I build software, put AI to practical use, and share what I learn through blog posts and my own open source projects."
       )
 
     {:ok, socket}

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -1,5 +1,5 @@
-<Layouts.app current_url={@current_url}>
-  <section aria-labelledby="home-heading" class="max-w-3xl pb-10 md:pb-14">
+<Layouts.app current_url={@current_url} main_class="pt-6 pb-4 md:pt-8 md:pb-6">
+  <section aria-labelledby="home-heading" class="max-w-3xl">
     <h1
       id="home-heading"
       class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl"
@@ -7,19 +7,19 @@
       Hi, I’m Florian.
     </h1>
 
-    <p class="text-base-content/70 mt-5 max-w-2xl text-lg leading-relaxed">
+    <p class="text-base-content/70 mt-3 max-w-2xl text-lg leading-relaxed">
       I’m a software engineer focused on using AI to improve development workflows without losing
       quality. I build open source projects, explore new technologies, and share what I learn.
     </p>
 
-    <nav aria-label="Contact" class="mt-6">
+    <nav aria-label="Contact" class="mt-3">
       <.contact_links class="flex flex-wrap gap-x-4 gap-y-2 text-sm" />
     </nav>
   </section>
 
   <section
     aria-labelledby="latest-articles-heading"
-    class="pt-10 md:pt-12"
+    class="mt-8 md:mt-10"
   >
     <div class="flex items-baseline justify-between gap-4">
       <h2
@@ -36,7 +36,7 @@
       </.link>
     </div>
 
-    <.grid class="mt-5">
+    <.grid class="[&>article]:py-2 mt-2">
       <.blog_preview_card
         :for={article <- @articles}
         link={~p"/blog/#{article.slug}"}
@@ -52,7 +52,7 @@
 
   <section
     aria-labelledby="selected-projects-heading"
-    class="mt-12 pt-10 md:mt-16 md:pt-12"
+    class="mt-8 md:mt-10"
   >
     <div class="flex items-baseline justify-between gap-4">
       <h2
@@ -69,7 +69,7 @@
       </.link>
     </div>
 
-    <.grid class="mt-5">
+    <.grid class="[&>article]:py-3 mt-2">
       <.project_card
         :for={project <- @projects}
         title={project.title}

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -19,7 +19,7 @@
 
   <section
     aria-labelledby="latest-articles-heading"
-    class="border-base-content/10 border-t pt-10 md:pt-12"
+    class="pt-10 md:pt-12"
   >
     <div class="flex items-baseline justify-between gap-4">
       <h2
@@ -52,7 +52,7 @@
 
   <section
     aria-labelledby="selected-projects-heading"
-    class="border-base-content/10 mt-12 border-t pt-10 md:mt-16 md:pt-12"
+    class="mt-12 pt-10 md:mt-16 md:pt-12"
   >
     <div class="flex items-baseline justify-between gap-4">
       <h2

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -8,8 +8,9 @@
     </h1>
 
     <p class="text-base-content/70 mt-3 max-w-2xl text-lg leading-relaxed">
-      I’m a software engineer focused on using AI to improve development workflows without losing
-      quality. I build open source projects, explore new technologies, and share what I learn.
+      I’m a Lead Engineer at naymspace, building software and helping teams put AI to practical use.
+      I care about solutions that make everyday work easier and are worth the investment.
+      Here I share my projects and what I learn.
     </p>
 
     <nav aria-label="Contact" class="mt-3">

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -1,86 +1,45 @@
 <Layouts.app current_url={@current_url}>
-  <section class="pb-6 md:pb-8">
-    <h1 class="text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
-      <span class="text-base-content">Hey, I'm</span>
-      <span class={["from-primary to-secondary bg-linear-to-r", "bg-clip-text text-transparent"]}>
-        Florian!
-      </span>
+  <section aria-labelledby="home-heading" class="max-w-3xl pb-10 md:pb-14">
+    <h1 id="home-heading" class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+      Hi, I’m Florian.
     </h1>
 
-    <p class="text-base-content/70 mt-6 max-w-2xl text-base leading-relaxed md:text-lg">
-      Software Engineer passionate about leveraging AI to accelerate software development workflows,
-      always with a focus on quality. I build open source projects, explore new
-      technologies, and enjoy sharing what I learn.
+    <p class="text-base-content/70 mt-5 max-w-2xl text-lg leading-relaxed">
+      I’m a software engineer and computer science student based in Flensburg. I build software at
+      <.link
+        href="https://naymspace.de/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-base-content underline underline-offset-4"
+      >naymspace</.link>
+      and write about what I learn along the way.
     </p>
 
-    <div class="mt-8 flex flex-wrap gap-4">
-      <.link
-        navigate={~p"/blog"}
-        class={[
-          "inline-flex items-center gap-2 px-4 py-2 text-sm",
-          "bg-primary text-primary-content",
-          "rounded-lg font-medium",
-          "shadow-primary/25 shadow-lg",
-          "hover:shadow-primary/30 hover:shadow-xl hover:brightness-110",
-          "transition-[scale,box-shadow,filter] duration-200",
-          "active:scale-[0.98]"
-        ]}
-      >
-        Read my blog <.icon name="hero-arrow-right" class="size-4" />
-      </.link>
-
-      <.link
-        navigate={~p"/about"}
-        class={[
-          "inline-flex items-center gap-2 px-4 py-2 text-sm",
-          "bg-base-200 text-base-content",
-          "rounded-lg font-medium",
-          "border-base-content/5 border",
-          "hover:bg-base-300 hover:border-base-content/10",
-          "transition-colors duration-200",
-          "active:scale-[0.98]"
-        ]}
-      >
-        About me
-      </.link>
-    </div>
-
-    <div class="mt-12 md:mt-14">
-      <.section_label class="mb-4">Connect with me</.section_label>
-      <.contact_links
-        class="flex gap-3"
-        icon_class={[
-          "size-10 p-2.5",
-          "rounded-xl",
-          "bg-base-200/50 border border-base-content/5",
-          "text-base-content/70 fill-current",
-          "hover:bg-base-200 hover:text-primary hover:border-primary/20",
-          "transition-colors duration-200"
-        ]}
-      />
-    </div>
+    <nav aria-label="Contact" class="mt-6">
+      <.contact_links class="flex flex-wrap gap-x-4 gap-y-2 text-sm" />
+    </nav>
   </section>
 
-  <section class="pt-4 md:pt-6">
-    <div class="mb-8 flex items-end justify-between">
-      <div>
-        <.section_label class="mb-2">From the blog</.section_label>
-        <h2 class="text-base-content text-2xl font-bold md:text-3xl">Latest Articles</h2>
-      </div>
+  <section
+    aria-labelledby="latest-articles-heading"
+    class="border-base-content/10 border-t pt-10 md:pt-12"
+  >
+    <div class="flex items-baseline justify-between gap-4">
+      <h2
+        id="latest-articles-heading"
+        class="text-base-content text-xl font-semibold md:text-2xl"
+      >
+        Latest articles
+      </h2>
       <.link
         navigate={~p"/blog"}
-        class={[
-          "hidden items-center gap-2 sm:inline-flex",
-          "text-base-content/70 text-sm font-medium",
-          "hover:text-primary",
-          "transition-colors duration-200"
-        ]}
+        class="text-primary text-sm underline underline-offset-4"
       >
-        View all articles <.icon name="hero-arrow-right" class="size-4" />
+        View all
       </.link>
     </div>
 
-    <.grid>
+    <.grid class="mt-5">
       <.blog_preview_card
         :for={article <- @articles}
         link={~p"/blog/#{article.slug}"}
@@ -89,21 +48,39 @@
         description={article.description}
         read_minutes={article.read_minutes}
         heading_level={:h3}
+        compact
       />
     </.grid>
+  </section>
 
-    <.link
-      navigate={~p"/blog"}
-      class={[
-        "mt-8 flex items-center justify-center gap-2 sm:hidden",
-        "text-primary text-sm font-medium",
-        "rounded-xl px-4 py-3",
-        "bg-primary/5 border-primary/10 border",
-        "active:scale-[0.98]",
-        "transition-colors duration-200"
-      ]}
-    >
-      View all articles <.icon name="hero-arrow-right" class="size-4" />
-    </.link>
+  <section
+    aria-labelledby="selected-projects-heading"
+    class="border-base-content/10 mt-12 border-t pt-10 md:mt-16 md:pt-12"
+  >
+    <div class="flex items-baseline justify-between gap-4">
+      <h2
+        id="selected-projects-heading"
+        class="text-base-content text-xl font-semibold md:text-2xl"
+      >
+        Selected projects
+      </h2>
+      <.link
+        navigate={~p"/projects"}
+        class="text-primary text-sm underline underline-offset-4"
+      >
+        View all
+      </.link>
+    </div>
+
+    <.grid class="mt-5">
+      <.project_card
+        :for={project <- @projects}
+        title={project.title}
+        description={project.description}
+        link={project.link}
+        link_label={project.link_label}
+        heading_level={:h3}
+      />
+    </.grid>
   </section>
 </Layouts.app>

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -5,14 +5,8 @@
     </h1>
 
     <p class="text-base-content/70 mt-5 max-w-2xl text-lg leading-relaxed">
-      I’m a software engineer and computer science student based in Flensburg. I build software at
-      <.link
-        href="https://naymspace.de/"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-base-content underline underline-offset-4"
-      >naymspace</.link>
-      and write about what I learn along the way.
+      I’m a software engineer focused on using AI to improve development workflows without losing
+      quality. I build open source projects, explore new technologies, and share what I learn.
     </p>
 
     <nav aria-label="Contact" class="mt-6">
@@ -33,9 +27,9 @@
       </h2>
       <.link
         navigate={~p"/blog"}
-        class="text-primary text-sm underline underline-offset-4"
+        class="text-primary min-h-11 inline-flex items-center text-sm underline underline-offset-4"
       >
-        View all
+        View all articles
       </.link>
     </div>
 
@@ -66,9 +60,9 @@
       </h2>
       <.link
         navigate={~p"/projects"}
-        class="text-primary text-sm underline underline-offset-4"
+        class="text-primary min-h-11 inline-flex items-center text-sm underline underline-offset-4"
       >
-        View all
+        View all projects
       </.link>
     </div>
 

--- a/lib/website_web/live/home_live/index.html.heex
+++ b/lib/website_web/live/home_live/index.html.heex
@@ -1,6 +1,9 @@
 <Layouts.app current_url={@current_url}>
   <section aria-labelledby="home-heading" class="max-w-3xl pb-10 md:pb-14">
-    <h1 id="home-heading" class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+    <h1
+      id="home-heading"
+      class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl"
+    >
       Hi, I’m Florian.
     </h1>
 

--- a/lib/website_web/live/projects_live/index.html.heex
+++ b/lib/website_web/live/projects_live/index.html.heex
@@ -1,12 +1,15 @@
 <Layouts.app current_url={@current_url}>
-  <article class="relative">
-    <header>
-      <.page_intro title="Things I've built" label="Portfolio">
-        I've been involved in many projects and have already built some myself. Mostly these were university projects or side projects I built in my free time. These are the ones that I'm most proud of.
-      </.page_intro>
+  <article>
+    <header class="max-w-2xl">
+      <h1 class="text-base-content text-3xl font-semibold tracking-tight md:text-4xl">
+        Things I’ve built
+      </h1>
+      <p class="text-base-content/70 mt-5 leading-relaxed">
+        A selection of university, open source, and side projects I’ve enjoyed building.
+      </p>
     </header>
 
-    <.grid>
+    <.grid class="mt-8">
       <.project_card
         :for={project <- @projects}
         title={project.title}

--- a/lib/website_web/live/search_live.html.heex
+++ b/lib/website_web/live/search_live.html.heex
@@ -31,37 +31,41 @@
           onsubmit="return false"
         >
           <div class="border-base-content/10 flex items-center gap-3 border-b px-4 py-3">
-            <.icon name="hero-magnifying-glass" class="text-base-content/70 size-5 shrink-0" />
-            <label for="search-input" class="sr-only">Search articles</label>
-            <input
-              id="search-input"
-              type="text"
-              name="query"
-              value={@query}
-              placeholder="Search articles..."
-              autocomplete="off"
-              autofocus
-              role="combobox"
-              aria-label="Search articles"
-              aria-expanded={to_string(@open)}
-              aria-controls="search-results"
-              aria-activedescendant={if @results != [], do: "search-result-#{@selected_index}"}
-              phx-debounce="300"
-              phx-target={@myself}
-              class={[
-                "min-w-0 flex-1 border-none bg-transparent outline-none",
-                "text-base-content placeholder-base-content/70",
-                "text-base"
-              ]}
-            />
+            <label for="search-input" class="input input-primary min-h-11 min-w-0 flex-1 gap-2">
+              <.icon name="hero-magnifying-glass" class="text-base-content/70 size-5 shrink-0" />
+              <span class="sr-only">Search articles</span>
+              <input
+                id="search-input"
+                type="text"
+                name="query"
+                value={@query}
+                placeholder="Search articles..."
+                autocomplete="off"
+                autofocus
+                role="combobox"
+                aria-label="Search articles"
+                aria-expanded={to_string(@open)}
+                aria-controls="search-results"
+                aria-activedescendant={if @results != [], do: "search-result-#{@selected_index}"}
+                phx-debounce="300"
+                phx-target={@myself}
+                class={[
+                  "min-w-0 grow border-none bg-transparent",
+                  "text-base-content placeholder-base-content/70",
+                  "text-base"
+                ]}
+              />
+            </label>
             <button
               type="button"
               phx-click="close"
               phx-target={@myself}
-              class="min-h-11 min-w-11 text-sm"
+              class="btn btn-circle btn-ghost min-h-11 min-w-11 shrink-0"
               id="close-search"
               aria-label="Close search"
-            >Close</button>
+            >
+              <.icon name="hero-x-mark" class="size-5" />
+            </button>
           </div>
         </form>
 

--- a/lib/website_web/live/search_live.html.heex
+++ b/lib/website_web/live/search_live.html.heex
@@ -10,7 +10,7 @@
   >
     <%!-- Backdrop --%>
     <div
-      class="bg-black/60 fixed inset-0 backdrop-blur-sm"
+      class="bg-base-content/40 fixed inset-0"
       phx-click="close"
       phx-target={@myself}
     >
@@ -19,15 +19,20 @@
     <%!-- Modal --%>
     <div class="mt-[10vh] relative mx-auto max-w-2xl px-4">
       <div class={[
-        "bg-base-100 rounded-box",
+        "bg-base-100 rounded-md",
         "border-base-content/5 border",
-        "shadow-base-content/10 shadow-xl",
         "flex flex-col overflow-hidden"
       ]}>
         <%!-- Search input --%>
-        <form phx-change="search" phx-target={@myself} onsubmit="return false">
+        <form
+          id="article-search-form"
+          phx-change="search"
+          phx-target={@myself}
+          onsubmit="return false"
+        >
           <div class="border-base-content/10 flex items-center gap-3 border-b px-4 py-3">
-            <.icon name="hero-magnifying-glass" class="text-base-content/50 size-5 shrink-0" />
+            <.icon name="hero-magnifying-glass" class="text-base-content/70 size-5 shrink-0" />
+            <label for="search-input" class="sr-only">Search articles</label>
             <input
               id="search-input"
               type="text"
@@ -44,14 +49,19 @@
               phx-debounce="300"
               phx-target={@myself}
               class={[
-                "flex-1 border-none bg-transparent outline-none",
-                "text-base-content placeholder-base-content/40",
+                "min-w-0 flex-1 border-none bg-transparent outline-none",
+                "text-base-content placeholder-base-content/70",
                 "text-base"
               ]}
             />
-            <kbd class="bg-base-200 font-mono border-base-content/10 text-base-content/50 rounded border px-1.5 py-0.5 text-xs">
-              ESC
-            </kbd>
+            <button
+              type="button"
+              phx-click="close"
+              phx-target={@myself}
+              class="min-h-11 min-w-11 text-sm"
+              id="close-search"
+              aria-label="Close search"
+            >Close</button>
           </div>
         </form>
 
@@ -64,7 +74,7 @@
         >
           <div
             :if={@query != "" and @results == []}
-            class="text-base-content/50 px-4 py-12 text-center"
+            class="text-base-content/70 px-4 py-12 text-center"
           >
             <.icon name="hero-magnifying-glass" class="size-8 mx-auto mb-3 opacity-50" />
             <p>No articles found for "<span class="text-base-content">{@query}</span>"</p>
@@ -72,7 +82,7 @@
 
           <div
             :if={@query == ""}
-            class="text-base-content/50 px-4 py-12 text-center"
+            class="text-base-content/70 px-4 py-12 text-center"
           >
             <p>Start typing to search articles...</p>
           </div>
@@ -87,7 +97,7 @@
               phx-value-slug={result.article.slug}
               phx-target={@myself}
               class={[
-                "cursor-pointer px-4 py-3 transition-colors duration-100",
+                "cursor-pointer px-4 py-3 ",
                 if(index == @selected_index,
                   do: "bg-primary/10",
                   else: "hover:bg-base-content/5"
@@ -101,14 +111,14 @@
                 ]}>
                   {highlight(result.article.title, @query)}
                 </span>
-                <span class="bg-base-200 text-base-content/60 shrink-0 rounded-full px-2 py-0.5 text-xs">
+                <span class="bg-base-200 text-base-content/70 shrink-0 rounded-full px-2 py-0.5 text-xs">
                   {match_field_label(result.match_field)}
                 </span>
               </div>
-              <p :if={result.snippet} class="text-base-content/60 line-clamp-2 text-sm">
+              <p :if={result.snippet} class="text-base-content/70 line-clamp-2 text-sm">
                 {highlight(result.snippet, @query)}
               </p>
-              <div class="text-base-content/40 mt-1 flex items-center gap-2 text-xs">
+              <div class="text-base-content/70 mt-1 flex items-center gap-2 text-xs">
                 <span>{format_date(result.article.date)}</span>
                 <span>&middot;</span>
                 <span>{result.article.read_minutes} min read</span>
@@ -132,7 +142,7 @@
         <div
           :if={@results != []}
           aria-hidden="true"
-          class="border-base-content/10 text-base-content/40 flex items-center gap-4 border-t px-4 py-2.5 text-xs"
+          class="border-base-content/10 text-base-content/70 flex items-center gap-4 border-t px-4 py-2.5 text-xs"
         >
           <span class="flex items-center gap-1">
             <kbd class="bg-base-200 font-mono border-base-content/10 rounded border px-1 py-0.5">

--- a/lib/website_web/live/search_live.html.heex
+++ b/lib/website_web/live/search_live.html.heex
@@ -47,7 +47,7 @@
                 aria-expanded={to_string(@open)}
                 aria-controls="search-results"
                 aria-activedescendant={if @results != [], do: "search-result-#{@selected_index}"}
-                phx-debounce="300"
+                phx-throttle="300"
                 phx-target={@myself}
                 class={[
                   "min-w-0 grow border-none bg-transparent",

--- a/lib/website_web/seo.ex
+++ b/lib/website_web/seo.ex
@@ -21,7 +21,7 @@ defmodule WebsiteWeb.SEO do
       title: conn.assigns.page_title,
       card: :summary_large_image,
       image:
-        "https://og-image.farens.me/image?text=#{URI.encode(conn.assigns[:og_image_text] || "")}",
+        "https://og-image.farens.me/image?v=2&text=#{URI.encode(conn.assigns[:og_image_text] || "")}",
       description: conn.assigns[:meta_description] || @default_description
     )
   end
@@ -35,7 +35,7 @@ defmodule WebsiteWeb.SEO do
       description: conn.assigns[:meta_description] || @default_description,
       locale: "en_US",
       image:
-        "https://og-image.farens.me/image?text=#{URI.encode(conn.assigns[:og_image_text] || "")}",
+        "https://og-image.farens.me/image?v=2&text=#{URI.encode(conn.assigns[:og_image_text] || "")}",
       url: conn.assigns.current_url
     )
   end

--- a/lib/website_web/seo.ex
+++ b/lib/website_web/seo.ex
@@ -9,7 +9,7 @@ defmodule WebsiteWeb.SEO do
     open_graph: &__MODULE__.open_graph_config/1,
     twitter: &__MODULE__.twitter_config/1
 
-  @default_description "Personal website and blog of Florian Arens. Software Engineer passionate about leveraging AI to accelerate software development."
+  @default_description "Florian Arens, Lead Engineer at naymspace. I build software, put AI to practical use, and share what I learn through blog posts and my own open source projects."
 
   @doc """
   Configures the Twitter card.

--- a/test/website_web/browser/a11y_test.exs
+++ b/test/website_web/browser/a11y_test.exs
@@ -10,13 +10,13 @@ defmodule WebsiteWeb.A11yTest do
     "/about",
     "/blog",
     "/blog/tag/elixir",
-    # "/blog/hello-world",
+    "/blog/hello-world",
     "/projects",
     "/legal-notice",
     "/privacy-policy"
   ]
 
-  @themes ["light", "dark", "night", "sunset", "dracula"]
+  @themes ["light", "dark"]
 
   @moduletag :playwright
 

--- a/test/website_web/browser/interaction_test.exs
+++ b/test/website_web/browser/interaction_test.exs
@@ -1,0 +1,49 @@
+defmodule WebsiteWeb.InteractionTest do
+  use PhoenixTest.Playwright.Case, async: true
+
+  @moduletag :playwright
+  @moduletag browser_context_opts: [viewport: %{width: 390, height: 844}]
+
+  test "search can be closed with the keyboard after results arrive", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> click_button("Search articles")
+    |> fill_in("Search articles", with: "Phoenix")
+    |> assert_has("#search-results [role=option]")
+    |> press("#search-input", "Tab")
+    |> assert_has("#close-search:focus")
+    |> press("#close-search", "Enter")
+    |> refute_has("#search-overlay")
+    |> assert_has("button[aria-label='Search articles']:focus")
+  end
+
+  test "navigation and topic filters work on a narrow screen", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> click_link("nav[aria-label='Main navigation'] a", "Blog")
+    |> assert_path("/blog")
+    |> click_button("Elixir")
+    |> assert_path("/blog/tag/elixir")
+    |> assert_has("main button[aria-pressed=true]", text: "Elixir")
+    |> click_button("Elixir")
+    |> assert_path("/blog")
+    |> refute_has("main button[aria-pressed=true]")
+  end
+
+  test "theme choice survives navigation and a new page load", %{conn: conn} do
+    conn
+    |> visit("/")
+    |> click("#theme_switch summary")
+    |> click_button("Light")
+    |> assert_has("html[data-theme=light]")
+    |> click_link("nav[aria-label='Main navigation'] a", "About")
+    |> assert_has("html[data-theme=light]")
+    |> visit("/projects")
+    |> assert_has("html[data-theme=light]")
+    |> click("#theme_switch summary")
+    |> click_button("Dark")
+    |> assert_has("html[data-theme=dark]")
+    |> visit("/blog")
+    |> assert_has("html[data-theme=dark]")
+  end
+end

--- a/test/website_web/browser/interaction_test.exs
+++ b/test/website_web/browser/interaction_test.exs
@@ -46,4 +46,12 @@ defmodule WebsiteWeb.InteractionTest do
     |> visit("/blog")
     |> assert_has("html[data-theme=dark]")
   end
+
+  @tag browser_context_opts: [viewport: %{width: 1440, height: 900}]
+  test "desktop table of contents highlights the section reached by a link", %{conn: conn} do
+    conn
+    |> visit("/blog/how-to-get-user-ip-addresses-in-phoenix-liveview")
+    |> click_link("#desktop-toc a", "The more reliable way")
+    |> assert_has("#desktop-toc a[aria-current=location][href='#the-more-reliable-way']")
+  end
 end

--- a/test/website_web/live/navigation_test.exs
+++ b/test/website_web/live/navigation_test.exs
@@ -1,0 +1,41 @@
+defmodule WebsiteWeb.NavigationTest do
+  use WebsiteWeb.ConnCase, async: true
+
+  alias Website.Blog
+
+  test "an article can be opened from home and returned to the blog" do
+    article = Blog.all_articles() |> hd()
+
+    build_conn()
+    |> visit("/")
+    |> click_link(article.title)
+    |> assert_path("/blog/#{article.slug}")
+    |> assert_has("h1", text: article.title)
+    |> click_link("Back to articles")
+    |> assert_path("/blog")
+  end
+
+  test "topic filters update the article list and can be cleared" do
+    tag = Blog.all_tags() |> hd()
+    normalized_tag = String.downcase(tag)
+    matching_articles = Blog.articles_by_tag(normalized_tag)
+
+    session =
+      build_conn()
+      |> visit("/blog")
+      |> click_button(tag)
+      |> assert_path("/blog/tag/#{normalized_tag}")
+      |> assert_has("main button[aria-pressed=true]", text: tag)
+
+    session =
+      Enum.reduce(matching_articles, session, fn article, session ->
+        assert_has(session, "#articles a", text: article.title)
+      end)
+
+    session
+    |> click_button(tag)
+    |> assert_path("/blog")
+    |> refute_has("main button[aria-pressed=true]")
+    |> assert_has("#articles article", count: length(Blog.all_articles()))
+  end
+end

--- a/test/website_web/live/search_live_test.exs
+++ b/test/website_web/live/search_live_test.exs
@@ -35,7 +35,7 @@ defmodule WebsiteWeb.SearchLiveTest do
       |> assert_has("#search-overlay")
       |> unwrap(fn view ->
         view
-        |> Phoenix.LiveViewTest.element("#search-container [phx-click=\"close\"]")
+        |> Phoenix.LiveViewTest.element("#close-search")
         |> Phoenix.LiveViewTest.render_click()
       end)
       |> refute_has("#search-overlay")
@@ -56,7 +56,7 @@ defmodule WebsiteWeb.SearchLiveTest do
       end)
       |> unwrap(fn view ->
         view
-        |> Phoenix.LiveViewTest.element("#search-container [phx-click=\"close\"]")
+        |> Phoenix.LiveViewTest.element("#close-search")
         |> Phoenix.LiveViewTest.render_click()
       end)
       |> refute_has("#search-overlay")


### PR DESCRIPTION
## Summary
Simplify the portfolio and blog with a quieter, text-first layout. Remove decorative motion, gradients, shadows, and excess separators; tighten vertical spacing on the home page, related articles, and table of contents. Keep the pulsing active-reader indicator, respecting reduced-motion preferences.

- Use blue accents and cool gray surfaces in light and dark themes. Apply the saved or system theme before rendering, preserve explicit choices across navigation, and migrate removed theme choices to dark.
- Keep navigation visible across screen sizes and restore the sticky article TOC to the left on desktop, with collapsible contents on smaller screens and working active-section highlighting.
- Place the search icon inside the input, add an accessible X close button, throttle queries at 300 ms, and fix keyboard handling so the close button works after results arrive.
- Improve text and syntax-highlighting contrast, focus visibility, mobile touch targets, and regression coverage.

- Refresh the home intro, About page, and metadata to describe the current Lead Engineer role, practical AI work, business value, and open source contributions.

- Update Home and About social-image text and version OG image URLs to refresh immutable cached images.

## Deployment order
Deploy the companion OG generator change (https://github.com/Flo0807/og-image/pull/435) before this website change so the new URLs render the updated Lead Engineer subtitle.

## Validation
- `mix precommit`: 49 tests passed.
- Playwright accessibility suite: 16 tests passed across light and dark themes.
- Playwright interaction suite: 4 tests passed, covering keyboard search closing, mobile navigation and filtering, theme persistence, and desktop TOC tracking.
- Built assets and manually checked desktop, tablet, and mobile layouts and interactions throughout the changes.


